### PR TITLE
관리자용 쿠폰 관리 기능 추가

### DIFF
--- a/src/main/java/com/coupon/issuecouponservice/IssueCouponServiceApplication.java
+++ b/src/main/java/com/coupon/issuecouponservice/IssueCouponServiceApplication.java
@@ -17,7 +17,7 @@ public class IssueCouponServiceApplication {
 
 	@PostConstruct
 	public void init() {
-		TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+		TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
 	}
 
 }

--- a/src/main/java/com/coupon/issuecouponservice/controller/coupon/CouponAdminController.java
+++ b/src/main/java/com/coupon/issuecouponservice/controller/coupon/CouponAdminController.java
@@ -1,5 +1,6 @@
 package com.coupon.issuecouponservice.controller.coupon;
 
+import com.coupon.issuecouponservice.dto.request.coupon.CouponModificationParam;
 import com.coupon.issuecouponservice.dto.request.coupon.CouponCreationParam;
 import com.coupon.issuecouponservice.dto.response.ApiResponseForm;
 import com.coupon.issuecouponservice.dto.response.coupon.CouponForm;
@@ -34,5 +35,14 @@ public class CouponAdminController {
     public List<CouponForm> readAllCoupons() {
 
         return couponService.readAllCoupons();
+    }
+
+    @PatchMapping("/coupon/{couponId}")
+    public ResponseEntity<ApiResponseForm> modifyCoupon(@PathVariable("couponId") Long couponId,
+                                                        @RequestBody CouponModificationParam param) {
+
+        couponService.modifyCoupon(couponId, param);
+
+        return ResponseEntity.ok().body(new ApiResponseForm("쿠폰 생성 성공", HttpStatus.OK.value()));
     }
 }

--- a/src/main/java/com/coupon/issuecouponservice/controller/coupon/CouponAdminController.java
+++ b/src/main/java/com/coupon/issuecouponservice/controller/coupon/CouponAdminController.java
@@ -2,15 +2,15 @@ package com.coupon.issuecouponservice.controller.coupon;
 
 import com.coupon.issuecouponservice.dto.request.coupon.CouponCreationParam;
 import com.coupon.issuecouponservice.dto.response.ApiResponseForm;
+import com.coupon.issuecouponservice.dto.response.coupon.CouponForm;
 import com.coupon.issuecouponservice.service.coupon.CouponService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 import static com.coupon.issuecouponservice.domain.user.Role.Authority.ADMIN;
 
@@ -28,5 +28,11 @@ public class CouponAdminController {
         couponService.createCoupon(param);
 
         return ResponseEntity.ok().body(new ApiResponseForm("쿠폰 생성 성공", HttpStatus.OK.value()));
+    }
+
+    @GetMapping("/coupon")
+    public List<CouponForm> readAllCoupons() {
+
+        return couponService.readAllCoupons();
     }
 }

--- a/src/main/java/com/coupon/issuecouponservice/controller/coupon/CouponAdminController.java
+++ b/src/main/java/com/coupon/issuecouponservice/controller/coupon/CouponAdminController.java
@@ -45,4 +45,12 @@ public class CouponAdminController {
 
         return ResponseEntity.ok().body(new ApiResponseForm("쿠폰 생성 성공", HttpStatus.OK.value()));
     }
+
+    @DeleteMapping("/coupon/{couponId}")
+    public ResponseEntity<ApiResponseForm> deleteCoupon(@PathVariable("couponId") Long couponId) {
+
+        couponService.deleteCoupon(couponId);
+
+        return ResponseEntity.ok().body(new ApiResponseForm("쿠폰 삭제 성공", HttpStatus.OK.value()));
+    }
 }

--- a/src/main/java/com/coupon/issuecouponservice/controller/coupon/CouponAdminController.java
+++ b/src/main/java/com/coupon/issuecouponservice/controller/coupon/CouponAdminController.java
@@ -1,0 +1,32 @@
+package com.coupon.issuecouponservice.controller.coupon;
+
+import com.coupon.issuecouponservice.dto.request.coupon.CouponCreationParam;
+import com.coupon.issuecouponservice.dto.response.ApiResponseForm;
+import com.coupon.issuecouponservice.service.coupon.CouponService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.coupon.issuecouponservice.domain.user.Role.Authority.ADMIN;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin")
+@Secured(ADMIN)
+public class CouponAdminController {
+
+    private final CouponService couponService;
+
+    @PostMapping("/coupon")
+    public ResponseEntity<ApiResponseForm> createCoupon(@RequestBody CouponCreationParam param) {
+
+        couponService.createCoupon(param);
+
+        return ResponseEntity.ok().body(new ApiResponseForm("쿠폰 생성 성공", HttpStatus.OK.value()));
+    }
+}

--- a/src/main/java/com/coupon/issuecouponservice/domain/coupon/Coupon.java
+++ b/src/main/java/com/coupon/issuecouponservice/domain/coupon/Coupon.java
@@ -1,20 +1,20 @@
 package com.coupon.issuecouponservice.domain.coupon;
 
+import com.coupon.issuecouponservice.domain.common.Timestamped;
 import io.hypersistence.utils.hibernate.id.Tsid;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
 @Table(name = "coupon")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Coupon {
+public class Coupon extends Timestamped {
 
     @Id
     @Tsid
@@ -32,10 +32,15 @@ public class Coupon {
     @Column(name = "is_deleted", nullable = false)
     private boolean isDeleted;
 
+    @Column(name = "expired_at")
+    @Temporal(TemporalType.TIMESTAMP)
+    private LocalDateTime expiredAt;
+
     @Builder
-    public Coupon(String couponName, int totalQuantity, int remainQuantity) {
+    public Coupon(String couponName, int totalQuantity, int remainQuantity, LocalDateTime expiredAt) {
         this.couponName = couponName;
         this.totalQuantity = totalQuantity;
         this.remainQuantity = remainQuantity;
+        this.expiredAt = expiredAt;
     }
 }

--- a/src/main/java/com/coupon/issuecouponservice/domain/coupon/Coupon.java
+++ b/src/main/java/com/coupon/issuecouponservice/domain/coupon/Coupon.java
@@ -1,0 +1,41 @@
+package com.coupon.issuecouponservice.domain.coupon;
+
+import io.hypersistence.utils.hibernate.id.Tsid;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "coupon")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Coupon {
+
+    @Id
+    @Tsid
+    private Long id;
+
+    @Column(name = "coupon_name", nullable = false)
+    private String couponName;
+
+    @Column(name = "total_quantity", nullable = false)
+    private int totalQuantity;
+
+    @Column(name = "remain_quantity", nullable = false)
+    private int remainQuantity;
+
+    @Column(name = "is_deleted", nullable = false)
+    private boolean isDeleted;
+
+    @Builder
+    public Coupon(String couponName, int totalQuantity, int remainQuantity) {
+        this.couponName = couponName;
+        this.totalQuantity = totalQuantity;
+        this.remainQuantity = remainQuantity;
+    }
+}

--- a/src/main/java/com/coupon/issuecouponservice/domain/coupon/Coupon.java
+++ b/src/main/java/com/coupon/issuecouponservice/domain/coupon/Coupon.java
@@ -2,6 +2,7 @@ package com.coupon.issuecouponservice.domain.coupon;
 
 import com.coupon.issuecouponservice.domain.common.Timestamped;
 import com.coupon.issuecouponservice.dto.request.coupon.CouponCreationParam;
+import com.coupon.issuecouponservice.dto.request.coupon.CouponModificationParam;
 import io.hypersistence.utils.hibernate.id.Tsid;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -51,5 +52,23 @@ public class Coupon extends Timestamped {
                 .totalQuantity(param.getTotalQuantity())
                 .expiredAt(param.getExpiredAt())
                 .build();
+    }
+
+    public void modifyCoupon(CouponModificationParam param) {
+        if (!param.getCouponName().isBlank() && !this.couponName.equals(param.getCouponName())) {
+            this.couponName = param.getCouponName();
+        }
+
+        if (this.totalQuantity != param.getTotalQuantity()) {
+            this.totalQuantity = param.getTotalQuantity();
+        }
+
+        if (this.remainQuantity != param.getRemainQuantity()) {
+            this.remainQuantity = param.getRemainQuantity();
+        }
+
+        if (param.getExpiredAt() != null && !this.expiredAt.equals(param.getExpiredAt())) {
+            this.expiredAt = param.getExpiredAt();
+        }
     }
 }

--- a/src/main/java/com/coupon/issuecouponservice/domain/coupon/Coupon.java
+++ b/src/main/java/com/coupon/issuecouponservice/domain/coupon/Coupon.java
@@ -1,6 +1,7 @@
 package com.coupon.issuecouponservice.domain.coupon;
 
 import com.coupon.issuecouponservice.domain.common.Timestamped;
+import com.coupon.issuecouponservice.dto.request.coupon.CouponCreationParam;
 import io.hypersistence.utils.hibernate.id.Tsid;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -37,10 +38,18 @@ public class Coupon extends Timestamped {
     private LocalDateTime expiredAt;
 
     @Builder
-    public Coupon(String couponName, int totalQuantity, int remainQuantity, LocalDateTime expiredAt) {
+    public Coupon(String couponName, int totalQuantity, LocalDateTime expiredAt) {
         this.couponName = couponName;
         this.totalQuantity = totalQuantity;
-        this.remainQuantity = remainQuantity;
+        this.remainQuantity = totalQuantity; // 생성 시점에서 초기 잔여 수량은 전체 수량이다.
         this.expiredAt = expiredAt;
+    }
+
+    public static Coupon CreateCoupon(CouponCreationParam param) {
+        return Coupon.builder()
+                .couponName(param.getCouponName())
+                .totalQuantity(param.getTotalQuantity())
+                .expiredAt(param.getExpiredAt())
+                .build();
     }
 }

--- a/src/main/java/com/coupon/issuecouponservice/domain/coupon/Coupon.java
+++ b/src/main/java/com/coupon/issuecouponservice/domain/coupon/Coupon.java
@@ -46,6 +46,7 @@ public class Coupon extends Timestamped {
         this.expiredAt = expiredAt;
     }
 
+    /* == 생성 메서드 == */
     public static Coupon CreateCoupon(CouponCreationParam param) {
         return Coupon.builder()
                 .couponName(param.getCouponName())
@@ -54,6 +55,7 @@ public class Coupon extends Timestamped {
                 .build();
     }
 
+    /* == 수정 메서드 == */
     public void modifyCoupon(CouponModificationParam param) {
         if (!param.getCouponName().isBlank() && !this.couponName.equals(param.getCouponName())) {
             this.couponName = param.getCouponName();
@@ -70,5 +72,10 @@ public class Coupon extends Timestamped {
         if (param.getExpiredAt() != null && !this.expiredAt.equals(param.getExpiredAt())) {
             this.expiredAt = param.getExpiredAt();
         }
+    }
+
+    /* == 삭제 메서드 == */
+    public void deleteCoupon() {
+        this.isDeleted = true;
     }
 }

--- a/src/main/java/com/coupon/issuecouponservice/dto/request/coupon/CouponCreationParam.java
+++ b/src/main/java/com/coupon/issuecouponservice/dto/request/coupon/CouponCreationParam.java
@@ -1,0 +1,21 @@
+package com.coupon.issuecouponservice.dto.request.coupon;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class CouponCreationParam {
+
+    private String couponName;
+
+    private int totalQuantity;
+
+    private int remainQuantity;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm")
+    private LocalDateTime expiredAt;
+}

--- a/src/main/java/com/coupon/issuecouponservice/dto/request/coupon/CouponModificationParam.java
+++ b/src/main/java/com/coupon/issuecouponservice/dto/request/coupon/CouponModificationParam.java
@@ -1,0 +1,22 @@
+package com.coupon.issuecouponservice.dto.request.coupon;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+
+@Getter
+@NoArgsConstructor
+public class CouponModificationParam {
+
+    private String couponName;
+
+    private int totalQuantity;
+
+    private int remainQuantity;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm")
+    private LocalDateTime expiredAt;
+}

--- a/src/main/java/com/coupon/issuecouponservice/dto/response/coupon/CouponForm.java
+++ b/src/main/java/com/coupon/issuecouponservice/dto/response/coupon/CouponForm.java
@@ -1,0 +1,24 @@
+package com.coupon.issuecouponservice.dto.response.coupon;
+
+import com.coupon.issuecouponservice.domain.coupon.Coupon;
+import jakarta.persistence.Column;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class CouponForm {
+    private Long couponId;
+    private int totalQuantity;
+    private int remainQuantity;
+    private LocalDateTime expiredAt;
+
+    public CouponForm(Coupon coupon) {
+        this.couponId = coupon.getId();
+        this.totalQuantity = coupon.getTotalQuantity();
+        this.remainQuantity = coupon.getRemainQuantity();
+        this.expiredAt = coupon.getExpiredAt();
+    }
+}

--- a/src/main/java/com/coupon/issuecouponservice/repository/coupon/CouponRepository.java
+++ b/src/main/java/com/coupon/issuecouponservice/repository/coupon/CouponRepository.java
@@ -5,9 +5,14 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
+
 public interface CouponRepository extends JpaRepository<Coupon, Long> {
     @Query("select count(c) > 0 from Coupon c " +
             "where lower(replace(c.couponName, ' ', '')) = lower(replace(:couponName, ' ', '')) " +
             "and c.isDeleted = false")
     boolean existsByCouponName(@Param("couponName") String couponName);
+
+    @Query("select c from Coupon c where c.isDeleted = false order by c.createdAt desc")
+    List<Coupon> findAllCoupons();
 }

--- a/src/main/java/com/coupon/issuecouponservice/repository/coupon/CouponRepository.java
+++ b/src/main/java/com/coupon/issuecouponservice/repository/coupon/CouponRepository.java
@@ -1,0 +1,13 @@
+package com.coupon.issuecouponservice.repository.coupon;
+
+import com.coupon.issuecouponservice.domain.coupon.Coupon;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface CouponRepository extends JpaRepository<Coupon, Long> {
+    @Query("select count(c) > 0 from Coupon c " +
+            "where lower(replace(c.couponName, ' ', '')) = lower(replace(:couponName, ' ', '')) " +
+            "and c.isDeleted = false")
+    boolean existsByCouponName(@Param("couponName") String couponName);
+}

--- a/src/main/java/com/coupon/issuecouponservice/repository/coupon/CouponRepository.java
+++ b/src/main/java/com/coupon/issuecouponservice/repository/coupon/CouponRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CouponRepository extends JpaRepository<Coupon, Long> {
     @Query("select count(c) > 0 from Coupon c " +
@@ -15,4 +16,7 @@ public interface CouponRepository extends JpaRepository<Coupon, Long> {
 
     @Query("select c from Coupon c where c.isDeleted = false order by c.createdAt desc")
     List<Coupon> findAllCoupons();
+
+    @Query("select c from Coupon c where c.id = :couponId and c.isDeleted = false")
+    Optional<Coupon> findOneCouponByCouponId(@Param("couponId") Long couponId);
 }

--- a/src/main/java/com/coupon/issuecouponservice/service/coupon/CouponService.java
+++ b/src/main/java/com/coupon/issuecouponservice/service/coupon/CouponService.java
@@ -2,10 +2,14 @@ package com.coupon.issuecouponservice.service.coupon;
 
 import com.coupon.issuecouponservice.domain.coupon.Coupon;
 import com.coupon.issuecouponservice.dto.request.coupon.CouponCreationParam;
+import com.coupon.issuecouponservice.dto.response.coupon.CouponForm;
 import com.coupon.issuecouponservice.repository.coupon.CouponRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -28,5 +32,14 @@ public class CouponService {
         if (exists) {
             throw new IllegalArgumentException("이미 존재하는 쿠폰명입니다.");
         }
+    }
+
+    @Transactional(readOnly = true)
+    public List<CouponForm> readAllCoupons() {
+        List<Coupon> findCoupons = couponRepository.findAllCoupons();
+
+        return findCoupons.stream()
+                .map(CouponForm::new)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/coupon/issuecouponservice/service/coupon/CouponService.java
+++ b/src/main/java/com/coupon/issuecouponservice/service/coupon/CouponService.java
@@ -37,11 +37,16 @@ public class CouponService {
     }
 
     public void modifyCoupon(Long couponId, CouponModificationParam param) {
-        Coupon coupon = getCoupon(couponId);
+        Coupon findCoupon = getCoupon(couponId);
 
-        coupon.modifyCoupon(param);
+        findCoupon.modifyCoupon(param);
     }
 
+    public void deleteCoupon(Long couponId) {
+        Coupon findCoupon = getCoupon(couponId);
+
+        findCoupon.deleteCoupon();
+    }
 
 
     // 쿠폰 조회

--- a/src/main/java/com/coupon/issuecouponservice/service/coupon/CouponService.java
+++ b/src/main/java/com/coupon/issuecouponservice/service/coupon/CouponService.java
@@ -2,6 +2,7 @@ package com.coupon.issuecouponservice.service.coupon;
 
 import com.coupon.issuecouponservice.domain.coupon.Coupon;
 import com.coupon.issuecouponservice.dto.request.coupon.CouponCreationParam;
+import com.coupon.issuecouponservice.dto.request.coupon.CouponModificationParam;
 import com.coupon.issuecouponservice.dto.response.coupon.CouponForm;
 import com.coupon.issuecouponservice.repository.coupon.CouponRepository;
 import lombok.RequiredArgsConstructor;
@@ -26,14 +27,6 @@ public class CouponService {
         couponRepository.save(coupon);
     }
 
-    private void checkForDuplicateCouponName(CouponCreationParam param) {
-        boolean exists = couponRepository.existsByCouponName(param.getCouponName());
-
-        if (exists) {
-            throw new IllegalArgumentException("이미 존재하는 쿠폰명입니다.");
-        }
-    }
-
     @Transactional(readOnly = true)
     public List<CouponForm> readAllCoupons() {
         List<Coupon> findCoupons = couponRepository.findAllCoupons();
@@ -41,5 +34,28 @@ public class CouponService {
         return findCoupons.stream()
                 .map(CouponForm::new)
                 .collect(Collectors.toList());
+    }
+
+    public void modifyCoupon(Long couponId, CouponModificationParam param) {
+        Coupon coupon = getCoupon(couponId);
+
+        coupon.modifyCoupon(param);
+    }
+
+
+
+    // 쿠폰 조회
+    private Coupon getCoupon(Long couponId) {
+        return couponRepository.findOneCouponByCouponId(couponId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 쿠폰입니다."));
+    }
+
+    // 쿠폰 검증
+    private void checkForDuplicateCouponName(CouponCreationParam param) {
+        boolean exists = couponRepository.existsByCouponName(param.getCouponName());
+
+        if (exists) {
+            throw new IllegalArgumentException("이미 존재하는 쿠폰명입니다.");
+        }
     }
 }

--- a/src/main/java/com/coupon/issuecouponservice/service/coupon/CouponService.java
+++ b/src/main/java/com/coupon/issuecouponservice/service/coupon/CouponService.java
@@ -1,0 +1,32 @@
+package com.coupon.issuecouponservice.service.coupon;
+
+import com.coupon.issuecouponservice.domain.coupon.Coupon;
+import com.coupon.issuecouponservice.dto.request.coupon.CouponCreationParam;
+import com.coupon.issuecouponservice.repository.coupon.CouponRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CouponService {
+
+    private final CouponRepository couponRepository;
+
+    public void createCoupon(CouponCreationParam param) {
+        checkForDuplicateCouponName(param);
+
+        Coupon coupon = Coupon.CreateCoupon(param);
+
+        couponRepository.save(coupon);
+    }
+
+    private void checkForDuplicateCouponName(CouponCreationParam param) {
+        boolean exists = couponRepository.existsByCouponName(param.getCouponName());
+
+        if (exists) {
+            throw new IllegalArgumentException("이미 존재하는 쿠폰명입니다.");
+        }
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #8

## 📝 Description

- 관리자 권한 제한: 쿠폰 관리 시스템에 접근할 수 있는 사용자를 ADMIN 권한을 가진 사용자로 제한함.

- 쿠폰 생성 기능:
1. 쿠폰 만료 시간을 "yyyy-MM-dd HH:mm" 형식의 문자열로 입력받음.
2. 쿠폰명 중복 검사: 입력된 쿠폰명이 데이터베이스에 이미 존재하는지 검증하며, 이 검증은 쿠폰명의 대소문자와 공백을 무시하고 비교하여 진행.
3. 중복된 쿠폰명이 존재할 경우, 예외를 발생시키고 쿠폰 생성을 중단함.

- 쿠폰 조회 기능:

1. 관리자는 생성된 모든 쿠폰을 조회할 수 있으며, 조회 시 쿠폰은 최신 생성 순으로 정렬됨.
2. 논리 삭제된 쿠폰은 조회 결과에서 제외.

- 쿠폰 수정 기능:

1. 쿠폰의 이름, 총 수량, 잔여 수량, 만료 날짜 등을 수정할 수 있음. 
2. 수정은 입력된 파라미터 값이 현재의 값과 다를 경우에만 업데이트를 수행.

- 쿠폰 삭제 기능: 쿠폰의 isDeleted 상태를 true로 변경하여 처리함.

## 💬 To Reivewers

- 처음에는 쿠폰을 조회하거나 수정할 때 본인이 생성한 쿠폰만 조회 및 수정을 가능하게 할 생각이었습니다. 
=> 그러나, Admin 은 누가 생성한 쿠폰인지 상관없이 모든 쿠폰을 조회할 수 있고, 모든 쿠폰을 수정할 수 있게 하였습니다. 
=> 이것에 대해서 어떻게 생각하시나요 ?

- 쿠폰 조회 시 order by 를 통해 desc 정렬을 하여, 최신순으로 정렬하도록 하였습니다.
=> 만료일자 순 정렬, 삭제된 쿠폰 조회 등과 같은 조회 메서드도 생성해야 할까요 ?
