### PR TITLE
쿠폰 수정 로직 개선 및 쿠폰 전체 조회 기능 보완

### DIFF
--- a/src/main/java/com/coupon/issuecouponservice/controller/coupon/CouponAdminController.java
+++ b/src/main/java/com/coupon/issuecouponservice/controller/coupon/CouponAdminController.java
@@ -43,7 +43,7 @@ public class CouponAdminController {
 
         couponService.modifyCoupon(couponId, param);
 
-        return ResponseEntity.ok().body(new ApiResponseForm("쿠폰 생성 성공", HttpStatus.OK.value()));
+        return ResponseEntity.ok().body(new ApiResponseForm("쿠폰 수정 성공", HttpStatus.OK.value()));
     }
 
     @DeleteMapping("/coupon/{couponId}")

--- a/src/main/java/com/coupon/issuecouponservice/domain/coupon/Coupon.java
+++ b/src/main/java/com/coupon/issuecouponservice/domain/coupon/Coupon.java
@@ -57,7 +57,7 @@ public class Coupon extends Timestamped {
 
     /* == 수정 메서드 == */
     public void modifyCoupon(CouponModificationParam param) {
-        if (!param.getCouponName().isBlank() && !this.couponName.equals(param.getCouponName())) {
+        if (param.getCouponName() != null && !param.getCouponName().isBlank() && !this.couponName.equals(param.getCouponName())) {
             this.couponName = param.getCouponName();
         }
 

--- a/src/main/java/com/coupon/issuecouponservice/dto/response/coupon/CouponForm.java
+++ b/src/main/java/com/coupon/issuecouponservice/dto/response/coupon/CouponForm.java
@@ -11,12 +11,14 @@ import java.time.LocalDateTime;
 @Getter
 public class CouponForm {
     private Long couponId;
+    private String couponName;
     private int totalQuantity;
     private int remainQuantity;
     private LocalDateTime expiredAt;
 
     public CouponForm(Coupon coupon) {
         this.couponId = coupon.getId();
+        this.couponName = coupon.getCouponName();
         this.totalQuantity = coupon.getTotalQuantity();
         this.remainQuantity = coupon.getRemainQuantity();
         this.expiredAt = coupon.getExpiredAt();

--- a/src/main/java/com/coupon/issuecouponservice/dto/response/coupon/CouponForm.java
+++ b/src/main/java/com/coupon/issuecouponservice/dto/response/coupon/CouponForm.java
@@ -1,9 +1,6 @@
 package com.coupon.issuecouponservice.dto.response.coupon;
 
 import com.coupon.issuecouponservice.domain.coupon.Coupon;
-import jakarta.persistence.Column;
-import jakarta.persistence.Temporal;
-import jakarta.persistence.TemporalType;
 import lombok.Getter;
 
 import java.time.LocalDateTime;

--- a/src/main/java/com/coupon/issuecouponservice/service/coupon/CouponService.java
+++ b/src/main/java/com/coupon/issuecouponservice/service/coupon/CouponService.java
@@ -20,7 +20,7 @@ public class CouponService {
     private final CouponRepository couponRepository;
 
     public void createCoupon(CouponCreationParam param) {
-        checkForDuplicateCouponName(param);
+        checkForDuplicateCouponName(param.getCouponName());
 
         Coupon coupon = Coupon.CreateCoupon(param);
 
@@ -37,6 +37,8 @@ public class CouponService {
     }
 
     public void modifyCoupon(Long couponId, CouponModificationParam param) {
+        checkForDuplicateCouponName(param.getCouponName());
+
         Coupon findCoupon = getCoupon(couponId);
 
         findCoupon.modifyCoupon(param);
@@ -56,8 +58,8 @@ public class CouponService {
     }
 
     // 쿠폰 검증
-    private void checkForDuplicateCouponName(CouponCreationParam param) {
-        boolean exists = couponRepository.existsByCouponName(param.getCouponName());
+    private void checkForDuplicateCouponName(String couponName) {
+        boolean exists = couponRepository.existsByCouponName(couponName);
 
         if (exists) {
             throw new IllegalArgumentException("이미 존재하는 쿠폰명입니다.");

--- a/src/main/java/com/coupon/issuecouponservice/service/coupon/CouponService.java
+++ b/src/main/java/com/coupon/issuecouponservice/service/coupon/CouponService.java
@@ -19,14 +19,16 @@ public class CouponService {
 
     private final CouponRepository couponRepository;
 
+    // 쿠폰 생성
     public void createCoupon(CouponCreationParam param) {
-        checkForDuplicateCouponName(param.getCouponName());
+        checkForDuplicateCouponName(param.getCouponName()); // 쿠폰 이름 중복 검증
 
         Coupon coupon = Coupon.CreateCoupon(param);
 
         couponRepository.save(coupon);
     }
 
+    // 쿠폰 전체 조회
     @Transactional(readOnly = true)
     public List<CouponForm> readAllCoupons() {
         List<Coupon> findCoupons = couponRepository.findAllCoupons();
@@ -36,14 +38,16 @@ public class CouponService {
                 .collect(Collectors.toList());
     }
 
+    // 쿠폰 수정
     public void modifyCoupon(Long couponId, CouponModificationParam param) {
-        checkForDuplicateCouponName(param.getCouponName());
+        checkForDuplicateCouponName(param.getCouponName()); // 쿠폰 이름 중복 검증
 
         Coupon findCoupon = getCoupon(couponId);
 
         findCoupon.modifyCoupon(param);
     }
 
+    // 쿠폰 삭제
     public void deleteCoupon(Long couponId) {
         Coupon findCoupon = getCoupon(couponId);
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #10 

## 📝 Description

- 쿠폰 조회 기능 개선: 쿠폰 조회 시 쿠폰의 이름도 함께 반환되도록 기능을 추가

- 쿠폰 수정 로직 개선:
1. 쿠폰 수정 기능에 null 검사를 추가하여 param.getCouponName()이 null이 아닐 때만 쿠폰 이름을 비교하고 업데이트
2. 쿠폰 수정 성공 시 사용자에게 "쿠폰 수정 성공" 메시지 출력
3. 쿠폰명의 중복 검사 로직을 포함시켜, 수정 과정에서 쿠폰명이 중복될 경우 예외를 발생시키고, 중복이 없을 때만 데이터베이스에 쿠폰을 저장하도록 처리

## 💬 To Reivewers

- 코드 검토 후 궁금한 것이 있다면 말씀부탁드립니다.
