### PR TITLE
컨트롤러 어노테이션 수정 및 UserCoupon 중복 방지 로직 개선

### DIFF
--- a/src/main/java/com/coupon/issuecouponservice/controller/coupon/CouponCommonController.java
+++ b/src/main/java/com/coupon/issuecouponservice/controller/coupon/CouponCommonController.java
@@ -6,7 +6,6 @@ import com.coupon.issuecouponservice.service.coupon.CouponService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;

--- a/src/main/java/com/coupon/issuecouponservice/controller/coupon/CouponCommonController.java
+++ b/src/main/java/com/coupon/issuecouponservice/controller/coupon/CouponCommonController.java
@@ -13,7 +13,6 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/common")
 public class CouponCommonController {
 
     private final CouponService couponService;

--- a/src/main/java/com/coupon/issuecouponservice/controller/coupon/CouponUserController.java
+++ b/src/main/java/com/coupon/issuecouponservice/controller/coupon/CouponUserController.java
@@ -11,10 +11,12 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+import static com.coupon.issuecouponservice.domain.user.Role.Authority.USER;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/user")
-@Secured("USER")
+@Secured(USER)
 public class CouponUserController {
 
     private final CouponService couponService;

--- a/src/main/java/com/coupon/issuecouponservice/domain/coupon/Coupon.java
+++ b/src/main/java/com/coupon/issuecouponservice/domain/coupon/Coupon.java
@@ -99,7 +99,6 @@ public class Coupon extends Timestamped {
     public void validateCoupon(Long couponId) {
         if(this.stockStatus.equals(StockStatus.OUT_OF_STOCK)) throw new IllegalArgumentException("쿠폰이 매진되었습니다.");
         if(this.expiredAt.isBefore(LocalDateTime.now())) throw new IllegalArgumentException("쿠폰이 만료되었습니다.");
-        if(couponAlreadyIssue(couponId)) throw new IllegalArgumentException("중복된 쿠폰입니다.");
     }
 
     /* == 검증 메서드 : 중복 검증  == */

--- a/src/main/java/com/coupon/issuecouponservice/domain/coupon/UserCoupon.java
+++ b/src/main/java/com/coupon/issuecouponservice/domain/coupon/UserCoupon.java
@@ -9,9 +9,11 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-@Table(name = "user_coupon")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "user_coupon", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"coupon_id", "user_id"})
+})
 public class UserCoupon {
 
     @Id

--- a/src/main/java/com/coupon/issuecouponservice/service/coupon/CouponService.java
+++ b/src/main/java/com/coupon/issuecouponservice/service/coupon/CouponService.java
@@ -26,7 +26,6 @@ public class CouponService {
 
     // 쿠폰 생성
     public void createCoupon(CouponCreationParam param) {
-
         // 쿠폰 이름 중복 검증
         checkForDuplicateCouponName(param.getCouponName());
 
@@ -48,7 +47,6 @@ public class CouponService {
 
     // 쿠폰 수정
     public void modifyCoupon(Long couponId, CouponModificationParam param) {
-
         // 쿠폰 이름 중복 검증
         checkForDuplicateCouponName(param.getCouponName());
 
@@ -61,7 +59,6 @@ public class CouponService {
 
     // 쿠폰 삭제
     public void deleteCoupon(Long couponId) {
-
         // 쿠폰 조회
         Coupon findCoupon = getCoupon(couponId);
 
@@ -72,7 +69,6 @@ public class CouponService {
     // 쿠폰 상세 조회
     @Transactional(readOnly = true)
     public CouponOneForm selectCoupon(Long couponId) {
-
         // 쿠폰 조회
         Coupon coupon = getCoupon(couponId);
 
@@ -82,7 +78,6 @@ public class CouponService {
 
     // 쿠폰 발급
     public void issueCoupon(CouponIssueParam couponIssueParam, User user) {
-
         // 쿠폰 조회
         Coupon coupon = getCoupon(couponIssueParam.getCouponId());
 
@@ -102,13 +97,11 @@ public class CouponService {
         // 쿠폰 목록 조회
         List<UserCoupon> findUserCoupons = userCouponQueryService.getUserCoupons(userId);
 
-
-       // 쿠폰 반환
+        // 쿠폰 반환
         return findUserCoupons.stream()
                 .map(uc -> new CouponForm(uc.getCoupon()))
                 .collect(Collectors.toList());
     }
-
 
 
     // 쿠폰 조회 메서드


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #18 

## 📝 Description

1. 컨트롤러 어노테이션 수정
- `@RequestMapping("/common")`이 불필요하여 해당 어노테이션을 제거.
- `@Secured("USER")` 어노테이션을 정적 임포트를 사용하여 `@Secured(USER)`로 변경. 

2.  UserCoupon 중복 수령 방지 로직 개선
- 기존 `Coupon` 엔티티 내에 존재하는 `validateCoupon` 메서드의 쿠폰 중복 검증 로직은 제대로 동작하지 않았음
- 이에 `UserCoupon` 엔티티에 `@UniqueConstraint`를 추가하여, 유저별로 동일한 쿠폰을 중복 수령하지 못하도록 수정.

## 💬 To Reivewers

- `UserCoupon` 엔티티에 유니크 제약조건을 어떻게 설정하였는지, 한 번 확인바랍니다 !
