### PR TITLE
쿠폰 관리 시스템 개선

### DIFF
--- a/src/main/java/com/coupon/issuecouponservice/domain/coupon/Coupon.java
+++ b/src/main/java/com/coupon/issuecouponservice/domain/coupon/Coupon.java
@@ -63,12 +63,14 @@ public class Coupon extends Timestamped {
 
 
     @Builder
-    public Coupon(String couponName, String couponImage, int totalQuantity, LocalDateTime expiredAt) {
+    public Coupon(String couponName, String couponContent, String couponImage, int totalQuantity, LocalDateTime expiredAt) {
         this.couponName = couponName;
+        this.couponContent = couponContent;
         this.couponImage = couponImage;
         this.totalQuantity = totalQuantity;
         this.remainQuantity = totalQuantity; // 생성 시점에서 초기 잔여 수량은 전체 수량이다.
         this.stockStatus = StockStatus.IN_STOCK;
+        this.couponStatus = CouponStatus.INACTIVE;
         this.expiredAt = expiredAt;
     }
 

--- a/src/main/java/com/coupon/issuecouponservice/domain/coupon/Coupon.java
+++ b/src/main/java/com/coupon/issuecouponservice/domain/coupon/Coupon.java
@@ -27,6 +27,9 @@ public class Coupon extends Timestamped {
     @Column(name = "coupon_name", nullable = false)
     private String couponName;
 
+    @Column(name = "coupon_content", nullable = false)
+    private String couponContent;
+
     @Column(name = "coupon_image")
     private String couponImage;
 
@@ -42,6 +45,10 @@ public class Coupon extends Timestamped {
     @Enumerated(EnumType.STRING)
     @Column(name = "stock_status")
     private StockStatus stockStatus;
+
+    @Column(name = "cutoff_at")
+    @Temporal(TemporalType.TIMESTAMP)
+    private LocalDateTime cutoff_at;
 
     @Column(name = "expired_at")
     @Temporal(TemporalType.TIMESTAMP)

--- a/src/main/java/com/coupon/issuecouponservice/domain/coupon/Coupon.java
+++ b/src/main/java/com/coupon/issuecouponservice/domain/coupon/Coupon.java
@@ -46,6 +46,10 @@ public class Coupon extends Timestamped {
     @Column(name = "stock_status")
     private StockStatus stockStatus;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "coupon_status")
+    private CouponStatus couponStatus;
+
     @Column(name = "cutoff_at")
     @Temporal(TemporalType.TIMESTAMP)
     private LocalDateTime cutoff_at;

--- a/src/main/java/com/coupon/issuecouponservice/domain/coupon/CouponStatus.java
+++ b/src/main/java/com/coupon/issuecouponservice/domain/coupon/CouponStatus.java
@@ -1,0 +1,7 @@
+package com.coupon.issuecouponservice.domain.coupon;
+
+public enum CouponStatus {
+    ACTIVE, // 쿠폰 활성화
+    INACTIVE, // 쿠폰 비활성화
+    EXPIRED // 쿠폰 만료 상태
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,8 +1,8 @@
 spring.application.name=Issue-Coupon-Service
 
-spring.datasource.url=jdbc:mysql://localhost:3306/test_coupon
-spring.datasource.username=root
-spring.datasource.password=dbsehdwn12!
+spring.datasource.url=${DB_URL}
+spring.datasource.username=${DB_USER}
+spring.datasource.password=${DB_PASSWORD}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 spring.jpa.hibernate.ddl-auto=update

--- a/src/test/java/com/coupon/issuecouponservice/service/coupon/CouponConcurrencyTest.java
+++ b/src/test/java/com/coupon/issuecouponservice/service/coupon/CouponConcurrencyTest.java
@@ -70,6 +70,7 @@ class CouponConcurrencyTest {
 
         coupon = Coupon.builder()
                 .couponName("테스트 쿠폰")
+                .couponContent("쿠폰입니다.")
                 .couponImage("image")
                 .expiredAt(LocalDateTime.now().plusDays(30))
                 .totalQuantity(100)

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -9,7 +9,5 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 
 spring.jpa.hibernate.ddl-auto=update
 
-spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
-
 spring.jpa.properties.hibernate.show_sql=true
 spring.jpa.properties.hibernate.format_sql=true


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #40 

## 📝 Description

- 쿠폰 발급 마감 시간을 나타내는 필드로 cutoiffAt 추가, 이를 통해 기존 쿠폰 만료 시간인 expiredAt 과 개념적 분리 달성

- 쿠폰의 설명 및 내용을 나타내는 필드 "content" 추가

- ACTIVE, INACTIVE, EXPIRED 등으로 쿠폰의 상태값을 표시

## 💬 To Reivewers

- 내용 없음

- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
