### PR TITLE
마이페이지 뷰와 백엔드 로직 통합

### DIFF
--- a/src/main/java/com/coupon/issuecouponservice/controller/HomeController.java
+++ b/src/main/java/com/coupon/issuecouponservice/controller/HomeController.java
@@ -1,9 +1,11 @@
 package com.coupon.issuecouponservice.controller;
 
 import com.coupon.issuecouponservice.dto.response.coupon.CouponOneForm;
+import com.coupon.issuecouponservice.security.userdetails.UserDetailsImpl;
 import com.coupon.issuecouponservice.service.coupon.CouponService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -38,7 +40,8 @@ public class HomeController {
     }
 
     @GetMapping("/my-page")
-    public String myPage() {
+    public String myPage(Model model, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        model.addAttribute("user", userDetails.getUser());
         return "my-page";
     }
 

--- a/src/main/java/com/coupon/issuecouponservice/controller/HomeController.java
+++ b/src/main/java/com/coupon/issuecouponservice/controller/HomeController.java
@@ -2,6 +2,7 @@ package com.coupon.issuecouponservice.controller;
 
 import com.coupon.issuecouponservice.dto.response.coupon.CouponForm;
 import com.coupon.issuecouponservice.dto.response.coupon.CouponOneForm;
+import com.coupon.issuecouponservice.dto.response.user.UserForm;
 import com.coupon.issuecouponservice.security.userdetails.UserDetailsImpl;
 import com.coupon.issuecouponservice.service.coupon.CouponService;
 import lombok.RequiredArgsConstructor;
@@ -44,9 +45,15 @@ public class HomeController {
 
     @GetMapping("/my-page")
     public String myPage(Model model, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        // 사용자 정보를 UserForm 객체로 변환
+        UserForm userForm = new UserForm(userDetails.getUser());
+
+        // 현재 로그인한 사용자의 모든 쿠폰을 조회
         List<CouponForm> coupons = couponService.readAllUserCoupons(userDetails.getUser());
-        model.addAttribute("user", userDetails.getUser());
+
+        model.addAttribute("user", userForm);
         model.addAttribute("coupons", coupons);
+
         return "my-page";
     }
 

--- a/src/main/java/com/coupon/issuecouponservice/controller/HomeController.java
+++ b/src/main/java/com/coupon/issuecouponservice/controller/HomeController.java
@@ -1,5 +1,6 @@
 package com.coupon.issuecouponservice.controller;
 
+import com.coupon.issuecouponservice.util.PaginationUtils;
 import com.coupon.issuecouponservice.dto.response.coupon.CouponForm;
 import com.coupon.issuecouponservice.dto.response.coupon.CouponOneForm;
 import com.coupon.issuecouponservice.dto.response.user.UserForm;
@@ -7,12 +8,13 @@ import com.coupon.issuecouponservice.security.userdetails.UserDetailsImpl;
 import com.coupon.issuecouponservice.service.coupon.CouponService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
-
-import java.util.List;
 
 @Controller
 @RequiredArgsConstructor
@@ -44,15 +46,17 @@ public class HomeController {
     }
 
     @GetMapping("/my-page")
-    public String myPage(Model model, @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        // 사용자 정보를 UserForm 객체로 변환
+    public String myPage(Model model, @AuthenticationPrincipal UserDetailsImpl userDetails,
+                         @PageableDefault(size = 5) Pageable pageable) {
         UserForm userForm = new UserForm(userDetails.getUser());
+        Page<CouponForm> coupons = couponService.readAllUserCoupons(userDetails.getUser(), pageable);
 
-        // 현재 로그인한 사용자의 모든 쿠폰을 조회
-        List<CouponForm> coupons = couponService.readAllUserCoupons(userDetails.getUser());
+        PaginationUtils paginationUtils = new PaginationUtils(coupons, 5);
 
         model.addAttribute("user", userForm);
         model.addAttribute("coupons", coupons);
+        model.addAttribute("count", (int) coupons.getTotalElements());
+        model.addAttribute("paginationUtils", paginationUtils);
 
         return "my-page";
     }

--- a/src/main/java/com/coupon/issuecouponservice/controller/HomeController.java
+++ b/src/main/java/com/coupon/issuecouponservice/controller/HomeController.java
@@ -1,5 +1,6 @@
 package com.coupon.issuecouponservice.controller;
 
+import com.coupon.issuecouponservice.dto.response.coupon.CouponForm;
 import com.coupon.issuecouponservice.dto.response.coupon.CouponOneForm;
 import com.coupon.issuecouponservice.security.userdetails.UserDetailsImpl;
 import com.coupon.issuecouponservice.service.coupon.CouponService;
@@ -9,6 +10,8 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+
+import java.util.List;
 
 @Controller
 @RequiredArgsConstructor
@@ -41,7 +44,9 @@ public class HomeController {
 
     @GetMapping("/my-page")
     public String myPage(Model model, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        List<CouponForm> coupons = couponService.readAllUserCoupons(userDetails.getUser());
         model.addAttribute("user", userDetails.getUser());
+        model.addAttribute("coupons", coupons);
         return "my-page";
     }
 

--- a/src/main/java/com/coupon/issuecouponservice/controller/coupon/CouponUserController.java
+++ b/src/main/java/com/coupon/issuecouponservice/controller/coupon/CouponUserController.java
@@ -6,11 +6,11 @@ import com.coupon.issuecouponservice.facade.RedissonLockFacade;
 import com.coupon.issuecouponservice.security.userdetails.UserDetailsImpl;
 import com.coupon.issuecouponservice.service.coupon.CouponService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 import static com.coupon.issuecouponservice.domain.user.Role.Authority.USER;
 
@@ -31,8 +31,8 @@ public class CouponUserController {
 
     // 사용자 쿠폰 전체 조회
     @GetMapping("/coupon")
-    public List<CouponForm> readAllUserCoupons(@AuthenticationPrincipal UserDetailsImpl userDetails){
-        return couponService.readAllUserCoupons(userDetails.getUser());
+    public Page<CouponForm> readAllUserCoupons(@AuthenticationPrincipal UserDetailsImpl userDetails, Pageable pageable){
+        return couponService.readAllUserCoupons(userDetails.getUser(), pageable);
     }
 
 }

--- a/src/main/java/com/coupon/issuecouponservice/controller/coupon/CouponUserController.java
+++ b/src/main/java/com/coupon/issuecouponservice/controller/coupon/CouponUserController.java
@@ -30,9 +30,9 @@ public class CouponUserController {
     }
 
     // 사용자 쿠폰 전체 조회
-    @GetMapping("/{userId}/coupon")
-    public List<CouponForm> readAllUserCoupons(@PathVariable Long userId){
-        return couponService.readAllUserCoupons(userId);
+    @GetMapping("/coupon")
+    public List<CouponForm> readAllUserCoupons(@AuthenticationPrincipal UserDetailsImpl userDetails){
+        return couponService.readAllUserCoupons(userDetails.getUser());
     }
 
 }

--- a/src/main/java/com/coupon/issuecouponservice/domain/common/Timestamped.java
+++ b/src/main/java/com/coupon/issuecouponservice/domain/common/Timestamped.java
@@ -1,12 +1,14 @@
 package com.coupon.issuecouponservice.domain.common;
 
 import jakarta.persistence.*;
+import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
+@Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public class Timestamped {

--- a/src/main/java/com/coupon/issuecouponservice/domain/coupon/Coupon.java
+++ b/src/main/java/com/coupon/issuecouponservice/domain/coupon/Coupon.java
@@ -50,6 +50,10 @@ public class Coupon extends Timestamped {
     @Column(name = "coupon_status")
     private CouponStatus couponStatus;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "validity_status")
+    private ValidityStatus validityStatus;
+
     @Column(name = "open_at")
     @Temporal(TemporalType.TIMESTAMP)
     private LocalDateTime openAt;
@@ -75,6 +79,7 @@ public class Coupon extends Timestamped {
         this.remainQuantity = totalQuantity; // 생성 시점에서 초기 잔여 수량은 전체 수량이다.
         this.stockStatus = StockStatus.IN_STOCK;
         this.couponStatus = CouponStatus.INACTIVE;
+        this.validityStatus = ValidityStatus.VALID;
         this.openAt = openAt;
         this.closedAt = closedAt;
         this.expiredAt = expiredAt;
@@ -144,5 +149,9 @@ public class Coupon extends Timestamped {
     /* == 쿠폰 상태값 변경 == */
     public void updateCouponStatus(CouponStatus couponStatus) {
         this.couponStatus = couponStatus;
+    }
+
+    public void updateValidityStatus(ValidityStatus validityStatus) {
+        this.validityStatus = validityStatus;
     }
 }

--- a/src/main/java/com/coupon/issuecouponservice/domain/coupon/UserCoupon.java
+++ b/src/main/java/com/coupon/issuecouponservice/domain/coupon/UserCoupon.java
@@ -1,5 +1,6 @@
 package com.coupon.issuecouponservice.domain.coupon;
 
+import com.coupon.issuecouponservice.domain.common.Timestamped;
 import com.coupon.issuecouponservice.domain.user.User;
 import io.hypersistence.utils.hibernate.id.Tsid;
 import jakarta.persistence.*;
@@ -14,7 +15,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "user_coupon", uniqueConstraints = {
         @UniqueConstraint(columnNames = {"coupon_id", "user_id"})
 })
-public class UserCoupon {
+public class UserCoupon extends Timestamped {
 
     @Id
     @Tsid

--- a/src/main/java/com/coupon/issuecouponservice/domain/coupon/ValidityStatus.java
+++ b/src/main/java/com/coupon/issuecouponservice/domain/coupon/ValidityStatus.java
@@ -1,0 +1,17 @@
+package com.coupon.issuecouponservice.domain.coupon;
+
+public enum ValidityStatus {
+    VALID("유효"),
+    EXPIRED("만료"),
+    EXPIRING_SOON("만료 임박");
+
+    private final String description;
+
+    ValidityStatus(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/src/main/java/com/coupon/issuecouponservice/dto/response/coupon/CouponForm.java
+++ b/src/main/java/com/coupon/issuecouponservice/dto/response/coupon/CouponForm.java
@@ -1,6 +1,7 @@
 package com.coupon.issuecouponservice.dto.response.coupon;
 
 import com.coupon.issuecouponservice.domain.coupon.Coupon;
+import com.coupon.issuecouponservice.domain.coupon.ValidityStatus;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
@@ -12,6 +13,7 @@ public class CouponForm {
     private int totalQuantity;
     private int remainQuantity;
     private int possessionCount;
+    private ValidityStatus validityStatus;
     private LocalDateTime createdAt;
     private LocalDateTime expiredAt;
 
@@ -20,6 +22,7 @@ public class CouponForm {
         this.couponName = coupon.getCouponName();
         this.totalQuantity = coupon.getTotalQuantity();
         this.remainQuantity = coupon.getRemainQuantity();
+        this.validityStatus = coupon.getValidityStatus();
         this.createdAt = coupon.getCreatedAt();
         this.expiredAt = coupon.getExpiredAt();
     }
@@ -30,6 +33,7 @@ public class CouponForm {
         this.totalQuantity = coupon.getTotalQuantity();
         this.remainQuantity = coupon.getRemainQuantity();
         this.possessionCount = possessionCount;
+        this.validityStatus = coupon.getValidityStatus();
         this.createdAt = createdAt;
         this.expiredAt = coupon.getExpiredAt();
     }

--- a/src/main/java/com/coupon/issuecouponservice/dto/response/coupon/CouponForm.java
+++ b/src/main/java/com/coupon/issuecouponservice/dto/response/coupon/CouponForm.java
@@ -13,7 +13,6 @@ public class CouponForm {
     private String couponContent;
     private int totalQuantity;
     private int remainQuantity;
-    private int possessionCount;
     private ValidityStatus validityStatus;
     private LocalDateTime createdAt;
     private LocalDateTime expiredAt;
@@ -28,13 +27,12 @@ public class CouponForm {
         this.expiredAt = coupon.getExpiredAt();
     }
 
-    public CouponForm(Coupon coupon, LocalDateTime createdAt, int possessionCount) {
+    public CouponForm(Coupon coupon, LocalDateTime createdAt) {
         this.couponId = coupon.getId();
         this.couponName = coupon.getCouponName();
         this.couponContent = coupon.getCouponContent();
         this.totalQuantity = coupon.getTotalQuantity();
         this.remainQuantity = coupon.getRemainQuantity();
-        this.possessionCount = possessionCount;
         this.validityStatus = coupon.getValidityStatus();
         this.createdAt = createdAt;
         this.expiredAt = coupon.getExpiredAt();

--- a/src/main/java/com/coupon/issuecouponservice/dto/response/coupon/CouponForm.java
+++ b/src/main/java/com/coupon/issuecouponservice/dto/response/coupon/CouponForm.java
@@ -11,6 +11,8 @@ public class CouponForm {
     private String couponName;
     private int totalQuantity;
     private int remainQuantity;
+    private int possessionCount;
+    private LocalDateTime createdAt;
     private LocalDateTime expiredAt;
 
     public CouponForm(Coupon coupon) {
@@ -18,6 +20,17 @@ public class CouponForm {
         this.couponName = coupon.getCouponName();
         this.totalQuantity = coupon.getTotalQuantity();
         this.remainQuantity = coupon.getRemainQuantity();
+        this.createdAt = coupon.getCreatedAt();
+        this.expiredAt = coupon.getExpiredAt();
+    }
+
+    public CouponForm(Coupon coupon, LocalDateTime createdAt, int possessionCount) {
+        this.couponId = coupon.getId();
+        this.couponName = coupon.getCouponName();
+        this.totalQuantity = coupon.getTotalQuantity();
+        this.remainQuantity = coupon.getRemainQuantity();
+        this.possessionCount = possessionCount;
+        this.createdAt = createdAt;
         this.expiredAt = coupon.getExpiredAt();
     }
 }

--- a/src/main/java/com/coupon/issuecouponservice/dto/response/coupon/CouponForm.java
+++ b/src/main/java/com/coupon/issuecouponservice/dto/response/coupon/CouponForm.java
@@ -10,6 +10,7 @@ import java.time.LocalDateTime;
 public class CouponForm {
     private Long couponId;
     private String couponName;
+    private String couponContent;
     private int totalQuantity;
     private int remainQuantity;
     private int possessionCount;
@@ -30,6 +31,7 @@ public class CouponForm {
     public CouponForm(Coupon coupon, LocalDateTime createdAt, int possessionCount) {
         this.couponId = coupon.getId();
         this.couponName = coupon.getCouponName();
+        this.couponContent = coupon.getCouponContent();
         this.totalQuantity = coupon.getTotalQuantity();
         this.remainQuantity = coupon.getRemainQuantity();
         this.possessionCount = possessionCount;

--- a/src/main/java/com/coupon/issuecouponservice/dto/response/user/UserForm.java
+++ b/src/main/java/com/coupon/issuecouponservice/dto/response/user/UserForm.java
@@ -1,0 +1,23 @@
+package com.coupon.issuecouponservice.dto.response.user;
+
+import com.coupon.issuecouponservice.domain.user.User;
+import lombok.Getter;
+
+@Getter
+public class UserForm {
+
+    private String nickName;
+
+    private String email;
+
+    private String image;
+
+    private String provider;
+
+    public UserForm(User user) {
+        this.nickName = user.getNickName();
+        this.email = user.getEmail();
+        this.image = user.getEmail();
+        this.provider = user.getProvider();
+    }
+}

--- a/src/main/java/com/coupon/issuecouponservice/repository/coupon/UserCouponRepository.java
+++ b/src/main/java/com/coupon/issuecouponservice/repository/coupon/UserCouponRepository.java
@@ -1,11 +1,11 @@
 package com.coupon.issuecouponservice.repository.coupon;
 
 import com.coupon.issuecouponservice.domain.coupon.UserCoupon;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-
-import java.util.List;
 
 public interface UserCouponRepository extends JpaRepository<UserCoupon, Long> {
 
@@ -13,7 +13,7 @@ public interface UserCouponRepository extends JpaRepository<UserCoupon, Long> {
             "join fetch uc.coupon " +
             "where uc.user.id = :userId " +
             "order by uc.createdAt desc")
-    List<UserCoupon> findUserCouponsByUserId(@Param("userId") Long userId);
+    Page<UserCoupon> findUserCouponsByUserId(@Param("userId") Long userId, Pageable pageable);
 
     Long countByCouponId(Long couponId);
 }

--- a/src/main/java/com/coupon/issuecouponservice/repository/coupon/UserCouponRepository.java
+++ b/src/main/java/com/coupon/issuecouponservice/repository/coupon/UserCouponRepository.java
@@ -11,7 +11,8 @@ public interface UserCouponRepository extends JpaRepository<UserCoupon, Long> {
 
     @Query("select uc from UserCoupon uc " +
             "join fetch uc.coupon " +
-            "where uc.user.id = :userId")
+            "where uc.user.id = :userId " +
+            "order by uc.createdAt desc")
     List<UserCoupon> findUserCouponsByUserId(@Param("userId") Long userId);
 
     Long countByCouponId(Long couponId);

--- a/src/main/java/com/coupon/issuecouponservice/security/userdetails/UserDetailsImpl.java
+++ b/src/main/java/com/coupon/issuecouponservice/security/userdetails/UserDetailsImpl.java
@@ -28,6 +28,10 @@ public class UserDetailsImpl implements UserDetails, OAuth2User {
         this.isNewUser = isNewUser;
     }
 
+    public void updateUser(User user) {
+        this.user = user;
+    }
+
     @Override
     public Map<String, Object> getAttributes() {
         return attributes;

--- a/src/main/java/com/coupon/issuecouponservice/service/coupon/CouponScheduler.java
+++ b/src/main/java/com/coupon/issuecouponservice/service/coupon/CouponScheduler.java
@@ -2,11 +2,13 @@ package com.coupon.issuecouponservice.service.coupon;
 
 import com.coupon.issuecouponservice.domain.coupon.Coupon;
 import com.coupon.issuecouponservice.domain.coupon.CouponStatus;
+import com.coupon.issuecouponservice.domain.coupon.ValidityStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.support.TransactionTemplate;
 
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 
 @Component
@@ -23,6 +25,9 @@ public class CouponScheduler {
 
         // 쿠폰 비활성화 스케줄
         taskScheduler.schedule(() -> deactivateCoupon(coupon.getId()), coupon.getClosedAt().atZone(ZoneId.systemDefault()).toInstant());
+
+        // 쿠폰 만료 임박 및 만료 스케줄
+        scheduleCouponValidityUpdate(coupon);
     }
 
     private void activateCoupon(Long couponId) {
@@ -37,6 +42,26 @@ public class CouponScheduler {
         transactionTemplate.execute(status -> {
             Coupon coupon = couponQueryService.getCoupon(couponId);
             coupon.updateCouponStatus(CouponStatus.CLOSED);
+            return null;
+        });
+    }
+
+    private void scheduleCouponValidityUpdate(Coupon coupon) {
+        // 만료 임박 스케줄 (14일 전)
+        if (coupon.getExpiredAt().minusDays(14).isAfter(LocalDateTime.now())) {
+            taskScheduler.schedule(() -> updateCouponValidityStatus(coupon.getId(), ValidityStatus.EXPIRING_SOON),
+                    coupon.getExpiredAt().minusDays(14).atZone(ZoneId.systemDefault()).toInstant());
+        }
+
+        // 만료 스케줄
+        taskScheduler.schedule(() -> updateCouponValidityStatus(coupon.getId(), ValidityStatus.EXPIRED),
+                coupon.getExpiredAt().atZone(ZoneId.systemDefault()).toInstant());
+    }
+
+    private void updateCouponValidityStatus(Long couponId, ValidityStatus newStatus) {
+        transactionTemplate.execute(status -> {
+            Coupon coupon = couponQueryService.getCoupon(couponId);
+            coupon.updateValidityStatus(newStatus);
             return null;
         });
     }

--- a/src/main/java/com/coupon/issuecouponservice/service/coupon/CouponService.java
+++ b/src/main/java/com/coupon/issuecouponservice/service/coupon/CouponService.java
@@ -10,6 +10,8 @@ import com.coupon.issuecouponservice.dto.response.coupon.CouponForm;
 import com.coupon.issuecouponservice.dto.response.coupon.CouponOneForm;
 import com.coupon.issuecouponservice.repository.coupon.CouponRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -103,18 +105,12 @@ public class CouponService {
 
     // 사용자 쿠폰 전체 조회
     @Transactional(readOnly = true)
-    public List<CouponForm> readAllUserCoupons(User user) {
-
+    public Page<CouponForm> readAllUserCoupons(User user, Pageable pageable) {
         // 쿠폰 목록 조회
-        List<UserCoupon> findUserCoupons = userCouponQueryService.getUserCoupons(user.getId());
-
-        // 쿠폰 개수 합산
-        int possessionCount = findUserCoupons.size();
+        Page<UserCoupon> findUserCoupons = userCouponQueryService.getUserCoupons(user.getId(), pageable);
 
         // 쿠폰 반환
-        return findUserCoupons.stream()
-                .map(uc -> new CouponForm(uc.getCoupon(), uc.getCreatedAt(), possessionCount))
-                .collect(Collectors.toList());
+        return findUserCoupons.map(uc -> new CouponForm(uc.getCoupon(), uc.getCreatedAt()));
     }
 
 

--- a/src/main/java/com/coupon/issuecouponservice/service/coupon/CouponService.java
+++ b/src/main/java/com/coupon/issuecouponservice/service/coupon/CouponService.java
@@ -103,14 +103,17 @@ public class CouponService {
 
     // 사용자 쿠폰 전체 조회
     @Transactional(readOnly = true)
-    public List<CouponForm> readAllUserCoupons(Long userId) {
+    public List<CouponForm> readAllUserCoupons(User user) {
 
         // 쿠폰 목록 조회
-        List<UserCoupon> findUserCoupons = userCouponQueryService.getUserCoupons(userId);
+        List<UserCoupon> findUserCoupons = userCouponQueryService.getUserCoupons(user.getId());
+
+        // 쿠폰 개수 합산
+        int possessionCount = findUserCoupons.size();
 
         // 쿠폰 반환
         return findUserCoupons.stream()
-                .map(uc -> new CouponForm(uc.getCoupon()))
+                .map(uc -> new CouponForm(uc.getCoupon(), uc.getCreatedAt(), possessionCount))
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/coupon/issuecouponservice/service/coupon/UserCouponQueryService.java
+++ b/src/main/java/com/coupon/issuecouponservice/service/coupon/UserCouponQueryService.java
@@ -3,9 +3,9 @@ package com.coupon.issuecouponservice.service.coupon;
 import com.coupon.issuecouponservice.domain.coupon.UserCoupon;
 import com.coupon.issuecouponservice.repository.coupon.UserCouponRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -13,8 +13,8 @@ public class UserCouponQueryService {
 
     private final UserCouponRepository userCouponRepository;
 
-    public List<UserCoupon> getUserCoupons(Long userId) {
-        return userCouponRepository.findUserCouponsByUserId(userId);
+    public Page<UserCoupon> getUserCoupons(Long userId, Pageable pageable) {
+        return userCouponRepository.findUserCouponsByUserId(userId, pageable);
     }
 
     public void saveUserCoupon(UserCoupon userCoupon) {

--- a/src/main/java/com/coupon/issuecouponservice/service/user/UserService.java
+++ b/src/main/java/com/coupon/issuecouponservice/service/user/UserService.java
@@ -3,8 +3,12 @@ package com.coupon.issuecouponservice.service.user;
 import com.coupon.issuecouponservice.domain.user.User;
 import com.coupon.issuecouponservice.dto.request.user.UserModificationParam;
 import com.coupon.issuecouponservice.repository.user.UserRepository;
+import com.coupon.issuecouponservice.security.userdetails.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,6 +25,23 @@ public class UserService {
         User findUser = getUser(user);
 
         findUser.modifyUserDetails(param);
+
+        // 현재 인증 객체 가져오기
+        Authentication currentAuth = SecurityContextHolder.getContext().getAuthentication();
+        UserDetailsImpl userDetails = (UserDetailsImpl) currentAuth.getPrincipal();
+
+        // UserDetailsImpl 내부의 User 정보 업데이트
+        userDetails.updateUser(findUser);
+
+        // 새로운 Authentication 객체 생성
+        Authentication newAuth = new UsernamePasswordAuthenticationToken(
+                userDetails,
+                currentAuth.getCredentials(),
+                currentAuth.getAuthorities()
+        );
+
+        // SecurityContext에 업데이트된 Authentication 객체 재설정
+        SecurityContextHolder.getContext().setAuthentication(newAuth);
     }
 
     private User getUser(User user) {

--- a/src/main/java/com/coupon/issuecouponservice/util/PaginationUtils.java
+++ b/src/main/java/com/coupon/issuecouponservice/util/PaginationUtils.java
@@ -1,0 +1,31 @@
+package com.coupon.issuecouponservice.util;
+
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+@Getter
+public class PaginationUtils {
+    private final int currentPage;
+    private final int totalPages;
+    private final int pageGroupSize;
+    private final int startPage;
+    private final int endPage;
+    private final int currentGroup;
+    private final boolean isFirstGroup;
+    private final boolean isLastGroup;
+    private final int totalGroups;
+
+    public PaginationUtils(Page<?> page, int pageGroupSize) {
+        this.currentPage = page.getNumber() + 1;
+        this.totalPages = page.getTotalPages();
+        this.pageGroupSize = pageGroupSize;
+
+        this.currentGroup = (currentPage - 1) / pageGroupSize;
+        this.startPage = currentGroup * pageGroupSize + 1;
+        this.endPage = Math.min(startPage + pageGroupSize - 1, totalPages);
+        this.totalGroups = (int) Math.ceil((double) totalPages / pageGroupSize);
+
+        this.isFirstGroup = currentGroup == 0;
+        this.isLastGroup = currentGroup == totalGroups - 1;
+    }
+}

--- a/src/main/resources/static/css/styles.css
+++ b/src/main/resources/static/css/styles.css
@@ -336,10 +336,10 @@ p {
 }
 
 .page-link[aria-label="First"],
-.page-link[aria-label="Previous group"],
-.page-link[aria-label="Next group"],
+.page-link[aria-label="Previous Group"],
+.page-link[aria-label="Next Group"],
 .page-link[aria-label="Last"] {
-    background-color: transparent; /* 예시: 배경색 */
+    background-color: transparent;
     color: #959595;
     border: 1px solid #959595;
 }
@@ -349,8 +349,8 @@ p {
 }
 
 .page-link[aria-label="First"]:hover,
-.page-link[aria-label="Previous group"]:hover,
-.page-link[aria-label="Next group"]:hover,
+.page-link[aria-label="Previous Group"]:hover,
+.page-link[aria-label="Next Group"]:hover,
 .page-link[aria-label="Last"]:hover {
     color: black;
     border: 1px solid black;

--- a/src/main/resources/static/js/profile-setup.js
+++ b/src/main/resources/static/js/profile-setup.js
@@ -25,7 +25,7 @@ document.getElementById("submit").addEventListener("click", function () {
     }).then(response => response.json())
         .then(data => {
             console.log("Success: ", data);
-            window.location.href = "/";
+            window.location.href = "/my-page";
         })
         .catch((error) => {
             console.error("Error: ", error);

--- a/src/main/resources/static/js/script.js
+++ b/src/main/resources/static/js/script.js
@@ -142,4 +142,35 @@ document.addEventListener('DOMContentLoaded', function() {
     updateRemainingTime(); // 초기 실행
 });
 
+document.addEventListener("DOMContentLoaded", function () {
+    const couponRows = document.querySelectorAll('tr[data-bs-toggle="modal"]');
+    couponRows.forEach(function(row) {
+        row.addEventListener('click', function() {
+            const couponName = this.getAttribute('data-name');
+            const couponDescription = this.getAttribute('data-description');
+            const createdDate = this.getAttribute('data-created');
+            const expiredDate = this.getAttribute('data-expired');
+            const couponStatus = this.getAttribute('data-status');
+
+            // 모달 요소에 값을 설정
+            document.getElementById('modalCouponName').innerText = couponName;
+            document.getElementById('modalCouponDescription').innerText = couponDescription;
+            document.getElementById('modalCouponCreated').innerText = createdDate;
+            document.getElementById('modalCouponExpired').innerText = expiredDate;
+            const statusBadge = document.getElementById('modalCouponStatus');
+            statusBadge.innerText = couponStatus;
+            switch(couponStatus) {
+                case '만료':
+                    statusBadge.className = 'badge bg-danger';
+                    break;
+                case '만료 임박':
+                    statusBadge.className = 'badge bg-warning';
+                    break;
+                case '유효':
+                    statusBadge.className = 'badge bg-success';
+                    break;
+            }
+        });
+    });
+});
 

--- a/src/main/resources/templates/my-page.html
+++ b/src/main/resources/templates/my-page.html
@@ -113,6 +113,11 @@
             </tr>
             </thead>
             <tbody>
+            <th:block th:if="${count == 0}">
+                <tr>
+                    <td colspan="4" class="text-center">현재 보유한 쿠폰이 없어요 😵‍💫</td>
+                </tr>
+            </th:block>
             <tr th:each="coupon : ${coupons}" th:data-bs-toggle="modal" th:data-bs-target="'#modalSheet'"
                 th:data-name="${coupon.couponName}"
                 th:data-description="${coupon.couponContent}"
@@ -136,7 +141,7 @@
             </tr>
             </tbody>
         </table>
-        <nav aria-label="Page navigation">
+        <nav aria-label="Page navigation" th:if="${count > 0}">
             <ul class="pagination mt-5">
                 <!-- 처음 페이지로 이동: 첫 번째 그룹에서는 항상 렌더링, 2페이지 이상에서 활성화 -->
                 <li class="page-item" th:if="${paginationUtils.totalGroups > 1 || paginationUtils.currentPage > 1}">

--- a/src/main/resources/templates/my-page.html
+++ b/src/main/resources/templates/my-page.html
@@ -113,20 +113,23 @@
             </tr>
             </thead>
             <tbody>
-            <tr th:each="coupon : ${coupons}" th:data-bs-toggle="'modal'" th:data-bs-target="'#modalSheet'">
+            <tr th:each="coupon : ${coupons}" th:data-bs-toggle="modal" th:data-bs-target="'#modalSheet'"
+                th:data-name="${coupon.couponName}"
+                th:data-description="${coupon.couponContent}"
+                th:data-status="${coupon.validityStatus.description}"
+                th:data-created="${#temporals.format(coupon.createdAt, 'yyyy-MM-dd')}"
+                th:data-expired="${#temporals.format(coupon.expiredAt, 'yyyy-MM-dd')}">
+
                 <td th:text="${coupon.couponName}">쿠폰 이름</td>
                 <td th:text="${#temporals.format(coupon.createdAt, 'yyyy-MM-dd')}">발행 일자</td>
                 <td th:text="${#temporals.format(coupon.expiredAt, 'yyyy-MM-dd')}">만료 일자</td>
                 <td>
-                <span th:if="${coupon.expiredAt.isBefore(T(java.time.LocalDateTime).now())}"
-                        class="badge bg-danger" th:text="'만료'"></span>
-                    <span th:if="${T(java.time.Duration).between(T(java.time.LocalDateTime).now(), coupon.expiredAt).toDays() <= 14
-                   and T(java.time.Duration).between(T(java.time.LocalDateTime).now(), coupon.expiredAt).toDays() > 0}"
-                          class="badge bg-warning" th:text="'만료 임박'"></span>
-                    <span th:if="${T(java.time.Duration).between(T(java.time.LocalDateTime).now(), coupon.expiredAt).toDays() > 14}"
-                          class="badge bg-success" th:text="'유효'"></span>
+                    <span th:switch="${coupon.validityStatus.description}">
+                        <span th:case="'만료'" class="badge bg-danger" th:text="${coupon.validityStatus.description}"></span>
+                        <span th:case="'만료 임박'" class="badge bg-warning" th:text="${coupon.validityStatus.description}"></span>
+                        <span th:case="'유효'" class="badge bg-success" th:text="${coupon.validityStatus.description}"></span>
+                    </span>
                 </td>
-
             </tr>
             </tbody>
         </table>
@@ -156,23 +159,22 @@
                           dominant-baseline="central">Thumbnail
                     </text>
                 </svg>
-                <div class="card-body d-flex flex-column mt-3">
+                <div class="card-body d-flex flex-column mt-3 w-100">
                     <div class="d-flex justify-content-between align-items-center">
-                        <h2 class="fw-normal">쿠폰 이름 1</h2>
-                        <span class="badge bg-success ms-1">유효</span>
+                        <h2 class="fw-normal" id="modalCouponName">쿠폰 이름</h2>
+                        <span class="badge bg-success ms-1" id="modalCouponStatus">유효</span>
                     </div>
-                    <p class="card-text">쿠폰에 대한 설명이 기재될 예정입니다. 이 쿠폰은 행운을 가져다주는 특별한 쿠폰으로,
-                        사용 시 당신에게 엄청난 행운이 찾아갈 것입니다. 얼른 쿠폰을 발급 받으세요. 100자</p>
+                    <p class="card-text" id="modalCouponDescription">쿠폰에 대한 설명이 기재될 예정입니다.</p>
                 </div>
             </div>
             <div class="container d-flex justify-content-between align-items-center p-3">
                 <small class="text-body-secondary">
                     <span>발행 일자 </span>
-                    <span>2023-06-01</span>
+                    <span id="modalCouponCreated">2023-06-01</span>
                 </small>
                 <small class="text-body-secondary">
                     <span>만료 일자 </span>
-                    <span>2023-12-01</span>
+                    <span id="modalCouponExpired">2023-12-01</span>
                 </small>
             </div>
         </div>

--- a/src/main/resources/templates/my-page.html
+++ b/src/main/resources/templates/my-page.html
@@ -101,7 +101,7 @@
         <div class="container d-flex justify-content-between mb-3">
             <h3 class="coupon-table-title"><i class="fi fi-rr-ticket rotate-90"></i>&nbsp;내 <span
                     class="color-coral">쿠폰</span> 현황</h3>
-            <p class="mt-1">나의 보유 쿠폰<span class="color-coral"> 5 </span>장</p>
+            <p class="mt-1">나의 보유 쿠폰 <span class="color-coral" th:text="${coupons.size()}"> </span> 장</p>
         </div>
         <table class="table coupon-table table-hover">
             <thead>
@@ -113,35 +113,20 @@
             </tr>
             </thead>
             <tbody>
-            <tr data-bs-toggle="modal" data-bs-target="#modalSheet">
-                <td>행운을 주는 펭귄쓰</td>
-                <td>2023-06-01</td>
-                <td>2023-12-01</td>
-                <td><span class="badge bg-success">유효</span></td>
-            </tr>
-            <tr data-bs-toggle="modal" data-bs-target="#modalSheet">
-                <td>아무 의미 없는 너굴맨</td>
-                <td>2023-06-05</td>
-                <td>2023-12-05</td>
-                <td><span class="badge bg-warning">만료 임박</span></td>
-            </tr>
-            <tr data-bs-toggle="modal" data-bs-target="#modalSheet">
-                <td>츄르를 노려보는 고양이</td>
-                <td>2023-06-10</td>
-                <td>2023-12-10</td>
-                <td><span class="badge bg-danger">만료</span></td>
-            </tr>
-            <tr data-bs-toggle="modal" data-bs-target="#modalSheet">
-                <td>멍 때리는 고라파덕</td>
-                <td>2023-06-15</td>
-                <td>2023-12-15</td>
-                <td><span class="badge bg-success">유효</span></td>
-            </tr>
-            <tr data-bs-toggle="modal" data-bs-target="#modalSheet">
-                <td>땅 파고 있는 두더지</td>
-                <td>2023-06-20</td>
-                <td>2023-12-20</td>
-                <td><span class="badge bg-warning">만료 임박</span></td>
+            <tr th:each="coupon : ${coupons}" th:data-bs-toggle="'modal'" th:data-bs-target="'#modalSheet'">
+                <td th:text="${coupon.couponName}">쿠폰 이름</td>
+                <td th:text="${#temporals.format(coupon.createdAt, 'yyyy-MM-dd')}">발행 일자</td>
+                <td th:text="${#temporals.format(coupon.expiredAt, 'yyyy-MM-dd')}">만료 일자</td>
+                <td>
+                <span th:if="${coupon.expiredAt.isBefore(T(java.time.LocalDateTime).now())}"
+                        class="badge bg-danger" th:text="'만료'"></span>
+                    <span th:if="${T(java.time.Duration).between(T(java.time.LocalDateTime).now(), coupon.expiredAt).toDays() <= 14
+                   and T(java.time.Duration).between(T(java.time.LocalDateTime).now(), coupon.expiredAt).toDays() > 0}"
+                          class="badge bg-warning" th:text="'만료 임박'"></span>
+                    <span th:if="${T(java.time.Duration).between(T(java.time.LocalDateTime).now(), coupon.expiredAt).toDays() > 14}"
+                          class="badge bg-success" th:text="'유효'"></span>
+                </td>
+
             </tr>
             </tbody>
         </table>

--- a/src/main/resources/templates/my-page.html
+++ b/src/main/resources/templates/my-page.html
@@ -101,7 +101,7 @@
         <div class="container d-flex justify-content-between mb-3">
             <h3 class="coupon-table-title"><i class="fi fi-rr-ticket rotate-90"></i>&nbsp;내 <span
                     class="color-coral">쿠폰</span> 현황</h3>
-            <p class="mt-1">나의 보유 쿠폰 <span class="color-coral" th:text="${coupons.size()}"> </span> 장</p>
+            <p class="mt-1">나의 보유 쿠폰 <span class="color-coral" th:text="${count}"> </span> 장</p>
         </div>
         <table class="table coupon-table table-hover">
             <thead>
@@ -125,14 +125,54 @@
                 <td th:text="${#temporals.format(coupon.expiredAt, 'yyyy-MM-dd')}">만료 일자</td>
                 <td>
                     <span th:switch="${coupon.validityStatus.description}">
-                        <span th:case="'만료'" class="badge bg-danger" th:text="${coupon.validityStatus.description}"></span>
-                        <span th:case="'만료 임박'" class="badge bg-warning" th:text="${coupon.validityStatus.description}"></span>
-                        <span th:case="'유효'" class="badge bg-success" th:text="${coupon.validityStatus.description}"></span>
+                        <span th:case="'만료'" class="badge bg-danger"
+                              th:text="${coupon.validityStatus.description}"></span>
+                        <span th:case="'만료 임박'" class="badge bg-warning"
+                              th:text="${coupon.validityStatus.description}"></span>
+                        <span th:case="'유효'" class="badge bg-success"
+                              th:text="${coupon.validityStatus.description}"></span>
                     </span>
                 </td>
             </tr>
             </tbody>
         </table>
+        <nav aria-label="Page navigation">
+            <ul class="pagination mt-5">
+                <!-- 처음 페이지로 이동: 첫 번째 그룹에서는 항상 렌더링, 2페이지 이상에서 활성화 -->
+                <li class="page-item" th:if="${paginationUtils.totalGroups > 1 || paginationUtils.currentPage > 1}">
+                    <a class="page-link" th:href="@{/my-page(page=0, size=${coupons.size})}" aria-label="First" th:classappend="${paginationUtils.currentPage == 1 ? 'disabled' : ''}">
+                        <i class="fa-solid fa-angles-left"></i>
+                    </a>
+                </li>
+
+                <!-- 이전 페이지 그룹으로 이동: 첫 번째 그룹에서는 렌더링되지만 비활성화 -->
+                <li class="page-item" th:if="${paginationUtils.totalGroups > 1}" th:classappend="${paginationUtils.isFirstGroup ? 'disabled' : ''}">
+                    <a class="page-link" th:href="@{/my-page(page=${paginationUtils.isFirstGroup ? paginationUtils.currentPage - 1 : paginationUtils.startPage - 2}, size=${coupons.size})}" aria-label="Previous Group">
+                        <i class="fa-solid fa-angle-left"></i>
+                    </a>
+                </li>
+
+                <!-- 페이지 번호 표시 -->
+                <li th:each="i : ${#numbers.sequence(paginationUtils.startPage, paginationUtils.endPage)}"
+                    th:class="${i == paginationUtils.currentPage ? 'page-item active' : 'page-item'}">
+                    <a class="page-link" th:href="@{/my-page(page=${i - 1}, size=${coupons.size})}" th:text="${i}"></a>
+                </li>
+
+                <!-- 다음 페이지 그룹으로 이동 -->
+                <li class="page-item" th:if="${!paginationUtils.isLastGroup}">
+                    <a class="page-link" th:href="@{/my-page(page=${paginationUtils.endPage}, size=${coupons.size})}" aria-label="Next Group">
+                        <i class="fa-solid fa-angle-right"></i>
+                    </a>
+                </li>
+
+                <!-- 마지막 페이지로 이동 -->
+                <li class="page-item" th:if="${!paginationUtils.isLastGroup}">
+                    <a class="page-link" th:href="@{/my-page(page=${paginationUtils.totalPages - 1}, size=${coupons.size})}" aria-label="Last">
+                        <i class="fa-solid fa-angles-right"></i>
+                    </a>
+                </li>
+            </ul>
+        </nav>
     </div>
 </div>
 

--- a/src/main/resources/templates/my-page.html
+++ b/src/main/resources/templates/my-page.html
@@ -70,7 +70,8 @@
                 </text>
             </svg>
             <div class="container d-flex flex-column justify-content-center align-items-center mt-3">
-                <h2 class="fw-normal mt-1">유저 1
+                <h2 class="fw-normal mt-1">
+                    <span th:text="${user.getNickName()}">유저 닉네임</span>
                     <span class="ms-1 f-4Regular">님</span>
                     <span class="ms-1">
                         <a href="/user/profile/setup">
@@ -78,9 +79,19 @@
                         </a>
                     </span>
                 </h2>
-                <div class="d-flex align-items-center gap-2">
-                    <img class="social-icon" src="/images/카카오-256.png" alt="카카오 이미지">
-                    <p class="mt-3"><span>카카오</span>로 로그인 중</p>
+                <div th:switch="${user.getProvider()}">
+                    <div th:case='kakao' class="d-flex align-items-center gap-2">
+                        <img src="/images/카카오-256.png" alt="카카오 이미지" class="social-icon">
+                        <p class="mt-3">카카오로 로그인 중</p>
+                    </div>
+                    <div th:case='google' class="d-flex align-items-center gap-2">
+                        <img src="/images/구글-256.png" alt="구글 이미지" class="social-icon">
+                        <p class="mt-3">구글로 로그인 중</p>
+                    </div>
+                    <div th:case='naver' class="d-flex align-items-center gap-2">
+                        <img src="/images/네이버-256.png" alt="네이버 이미지" class="social-icon">
+                        <p class="mt-3">네이버로 로그인 중</p>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #49 

## 📝 Description

1. 마이페이지 컨트롤러 및 뷰 템플릿 업데이트

- 사용자 정보 전달 로직을 개선하여 마이페이지에서 동적으로 사용자 닉네임 및 로그인 제공자를 표시합니다.
- Thymeleaf를 활용하여 사용자 프로필 정보를 동적으로 렌더링합니다.

2. 사용자 프로필 수정 로직 개선

- 사용자 정보가 변경되었을 때, 세션 정보를 갱신합니다.
- UserDetailsImpl 클래스 내 updateUser 메소드를 추가하여 사용자 정보를 업데이트합니다.

3. 사용자 쿠폰 조회 방식 변경

- 사용자 ID를 경로 변수에서 제거하고, 인증 정보를 기반으로 쿠폰을 조회하는 것으로 변경하였습니다.

4. UserCoupon 및 CouponForm 클래스 개선

- UserCoupon 클래스에 Timestamped 상속을 추가하여 생성 및 수정 날짜를 관리합니다.
- CouponForm 클래스를 수정하여 사용자가 보유한 쿠폰 수와 생성 날짜 정보를 포함시킵니다.

5. 마이 페이지의 쿠폰 정보 표시 로직 및 뷰 업데이트

- 사용자의 쿠폰 목록을 조회하고, 페이지에 동적으로 보유 쿠폰 수와 만료 상태를 표시합니다.

6. 페이징 네비게이션 로직 구현 및 HTML 구조 추가

- PaginationUtils 클래스를 생성하여 페이지 그룹 및 네비게이션 로직을 효율적으로 관리합니다.
- Pageable 매개변수를 활용한 동적 쿼리 구현을 통해 효율적인 페이지 처리를 지원합니다.

7. 조건부 쿠폰 목록 렌더링 및 페이징 네비게이션 구현

- 쿠폰 목록이 비어 있을 경우 사용자에게 '현재 보유한 쿠폰이 없어요 😵‍💫' 메시지를 표시합니다.
- 쿠폰이 있는 경우에만 페이지 네비게이션을 렌더링합니다.

## 💬 To Reivewers

- 각 기능에 대한 상세한 리뷰와 피드백을 부탁드립니다.
