### PR TITLE
쿠폰 생성 페이지 뷰와 백엔드 기능 연결

### DIFF
--- a/src/main/java/com/coupon/issuecouponservice/controller/coupon/CouponAdminController.java
+++ b/src/main/java/com/coupon/issuecouponservice/controller/coupon/CouponAdminController.java
@@ -37,4 +37,12 @@ public class CouponAdminController {
         couponService.deleteCoupon(couponId);
 
     }
+
+    @GetMapping("/coupon/exists")
+    public boolean checkCouponExists(@RequestParam String openAt, @RequestParam String closedAt) {
+
+        return couponService.checkCouponExists(openAt, closedAt);
+
+    }
+
 }

--- a/src/main/java/com/coupon/issuecouponservice/repository/coupon/CouponRepository.java
+++ b/src/main/java/com/coupon/issuecouponservice/repository/coupon/CouponRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -23,4 +24,7 @@ public interface CouponRepository extends JpaRepository<Coupon, Long> {
     // 진행 중 쿠폰 조회
     @Query("select c from Coupon c where c.couponStatus = 'ACTIVE' and c.isDeleted = false ")
     Optional<Coupon> findActiveCoupon();
+
+    // 특정 기간 내의 쿠폰 조회
+    boolean existsByOpenAtBetweenOrClosedAtBetween(LocalDateTime couponOpenAt, LocalDateTime couponClosedAt, LocalDateTime openAt, LocalDateTime closedAt);
 }

--- a/src/main/java/com/coupon/issuecouponservice/service/coupon/CouponService.java
+++ b/src/main/java/com/coupon/issuecouponservice/service/coupon/CouponService.java
@@ -15,6 +15,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -129,5 +130,11 @@ public class CouponService {
         }
     }
 
+    // 특정 기간(시작일, 마감일)에 존재하는 쿠폰 확인 메서드
+    public boolean checkCouponExists(String openAt, String closedAt) {
+        LocalDateTime openDateTime = LocalDateTime.parse(openAt);
+        LocalDateTime closedDateTime = LocalDateTime.parse(closedAt);
 
+        return couponRepository.existsByOpenAtBetweenOrClosedAtBetween(openDateTime, closedDateTime, openDateTime, closedDateTime);
+    }
 }

--- a/src/main/resources/static/js/create-coupon.js
+++ b/src/main/resources/static/js/create-coupon.js
@@ -63,22 +63,49 @@ document.getElementById("create").addEventListener("click", function () {
     };
     console.log("Sending data: ", formData);
 
-    fetch("/admin/coupon", requestOptions)
+    fetch(`/admin/coupon/exists?openAt=${encodeURIComponent(formData.openAt)}&closedAt=${encodeURIComponent(formData.closedAt)}`)
         .then(response => {
-            if (response.ok) {
-                return response.json().catch(() => ({}));  // 응답이 비어있으면 빈 객체 반환
-            } else {
-                return response.json().then(errorData => {
-                    throw new Error(errorData.error || "Unknown error");
-                });
+            if (!response.ok) {
+                throw new Error('Network response was not ok');
             }
+            return response.json();
         })
         .then(data => {
-            console.log("Success: ", data);
-            window.location.href = "/";
+            if (data) {
+                alert("해당 기간에 이미 쿠폰이 존재합니다.");
+            } else {
+                // 쿠폰 생성 요청
+                const requestOptions = {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify(formData)
+                };
+                console.log("Sending data: ", formData);
+
+                fetch("/admin/coupon", requestOptions)
+                    .then(response => {
+                        if (response.ok) {
+                            return response.json().catch(() => ({}));  // 응답이 비어있으면 빈 객체 반환
+                        } else {
+                            return response.json().then(errorData => {
+                                throw new Error(errorData.error || "Unknown error");
+                            });
+                        }
+                    })
+                    .then(data => {
+                        console.log("Success: ", data);
+                        window.location.href = "/";
+                    })
+                    .catch((error) => {
+                        console.error("Error: ", error);
+                        alert("쿠폰 생성에 실패했습니다.");
+                    });
+            }
         })
-        .catch((error) => {
-            console.error("Error: ", error);
-            alert("쿠폰 생성에 실패했습니다.");
+        .catch(error => {
+            console.error('Error checking coupon existence:', error);
+            alert('쿠폰 중복 확인 중 오류가 발생했습니다.');
         });
 });


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #46 

## 📝 Description

1. 쿠폰 생성 페이지 구현 및 기능 연결 
- 이미지 관련 작업은 추후 S3 도입시 구현 예정입니다.

2. `@JsonFormat` 어노테이션 제거
- 프론트엔드의 datetime-local 타입과 백엔드의 LocalDateTime 타입의 형식이 동일하여 `@JsonFormat` 애노테이션 불필요하다 판단하여 제거했습니다. 

3. `@Temporal` 어노테이션 제거
- `@Temporal` 은 Date 와 Calendar 에 사용하는 어노테이션입니다. LocalDateTime 은 Time 패키지에 속하는 클래스이기에 불필요하다 판단하여 제거했습니다.

4. Admin 권한을 제외한 다른 사용자 접근 불가
- UserController 에서 checkAdmin() 메서드를 추가했습니다. 현재 인증된 사용자의 권한을 확인하여 사용자가 ADMIN 권한을 가지고 있는지 검사 후 true 또는 false 를 반환하는 메서드입니다.

- document.addEventListener("DOMContentLoaded", function() {...} : HTML 문서가 로드되고 나서 바로 실행되는 이벤트 리스너입니다. 이 이벤트리스너를 사용해 ADMIN 권한을 가진 사용자가 아니라면 팝업을 띄우고 main 페이지로 이동하게 구현하였습니다.

5. 쿠폰 생성 시 시작일, 종료일, 마감일의 논리적 조건 설정
- [논리적 조건]
- openAt은 closedAt 보다 이전이어야 한다.
- closedAt은 expiredAt 보다 이전이어야 한다.
- 따라서, 쿠폰의 시작일(openAt), 마감일(closedAt), 만료일(expiredAt)은 시간순으로 설정되어야 합니다.
- 날짜 비교를 위해 Date 객체로 변환합니다.
 `const openAtDate = new Date(formData.openAt);`
 `const closedAtDate = new Date(formData.closedAt);`
 `const expiredAtDate = new Date(formData.expiredAt);`

6. 쿠폰 생성 시 기존 쿠폰의 오픈날, 마감날 중복 체크
- [생성하고자 하는 쿠폰의 openAt 과 closedAt 의 조건]
- 기존 쿠폰의 openAt 과 closedAt 날짜 사이에 위치하면 안된다. 
- 기존 쿠폰의 openAt 과 closedAt 의 날짜와 같으면 안된다.
- 기존 쿠폰의 closedAt 보다 이후여야 한다.

- CouponAdminController 에서 반환값을 boolean 값으로 가지는 checkCouponExists() 메서드를 추가했습니다. 
- openAt, closedAt 을 LocalDateTime 으로 파싱해준 뒤 쿼리 메서드를 통해 중복을 확인합니다.
- existsByOpenAtBetweenOrClosedAtBetween 에서의 매개변수는 생성하고자 하는 쿠폰 openAt, closedAt 과 기존 쿠폰의 openAt, closedAt 입니다. 

## 💬 To Reivewers

- 6번의 기능 구현이 잘 이루어졌는지 확인 부탁드립니다. 