### PR TITLE
쿠폰 생성 시 날짜 비교

### DIFF
--- a/src/main/java/com/coupon/issuecouponservice/controller/coupon/CouponAdminController.java
+++ b/src/main/java/com/coupon/issuecouponservice/controller/coupon/CouponAdminController.java
@@ -38,11 +38,4 @@ public class CouponAdminController {
 
     }
 
-    @GetMapping("/coupon/exists")
-    public boolean checkCouponExists(@RequestParam String openAt, @RequestParam String closedAt) {
-
-        return couponService.checkCouponExists(openAt, closedAt);
-
-    }
-
 }

--- a/src/main/java/com/coupon/issuecouponservice/domain/coupon/Coupon.java
+++ b/src/main/java/com/coupon/issuecouponservice/domain/coupon/Coupon.java
@@ -83,7 +83,9 @@ public class Coupon extends Timestamped {
     }
 
     /* == 생성 메서드 == */
-    public static Coupon CreateCoupon(CouponCreationParam param) {
+    public static Coupon CreateCoupon(CouponCreationParam param, List<Coupon> coupons) {
+        checkClosedAt(param, coupons);
+
         return Coupon.builder()
                 .couponName(param.getCouponName())
                 .couponContent(param.getCouponContent())
@@ -133,6 +135,16 @@ public class Coupon extends Timestamped {
             }
         }
         return false;
+    }
+
+    /* == 검증 메서드 : 날짜 검증  == */
+    private static void checkClosedAt(CouponCreationParam param, List<Coupon> coupons) {
+        if(!coupons.isEmpty()){
+            LocalDateTime lastCouponClosedAt = coupons.get(0).getClosedAt();
+            if(param.getOpenAt().isBefore(lastCouponClosedAt)){
+                throw new IllegalArgumentException("새 쿠폰의 시작일은 기존 쿠폰의 발급 마감일( " + lastCouponClosedAt + " )보다 이후여야 합니다.");
+            }
+        }
     }
 
     /* == 쿠폰 재고 감소 == */

--- a/src/main/java/com/coupon/issuecouponservice/repository/coupon/CouponRepository.java
+++ b/src/main/java/com/coupon/issuecouponservice/repository/coupon/CouponRepository.java
@@ -5,7 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 

--- a/src/main/java/com/coupon/issuecouponservice/repository/coupon/CouponRepository.java
+++ b/src/main/java/com/coupon/issuecouponservice/repository/coupon/CouponRepository.java
@@ -25,6 +25,5 @@ public interface CouponRepository extends JpaRepository<Coupon, Long> {
     @Query("select c from Coupon c where c.couponStatus = 'ACTIVE' and c.isDeleted = false ")
     Optional<Coupon> findActiveCoupon();
 
-    // 특정 기간 내의 쿠폰 조회
-    boolean existsByOpenAtBetweenOrClosedAtBetween(LocalDateTime couponOpenAt, LocalDateTime couponClosedAt, LocalDateTime openAt, LocalDateTime closedAt);
+    List<Coupon> findAllByOrderByClosedAtDesc();
 }

--- a/src/main/java/com/coupon/issuecouponservice/service/coupon/CouponService.java
+++ b/src/main/java/com/coupon/issuecouponservice/service/coupon/CouponService.java
@@ -15,9 +15,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -34,17 +32,11 @@ public class CouponService {
         // 쿠폰 이름 중복 검증
         checkForDuplicateCouponName(param.getCouponName());
 
-        // 쿠폰 날짜 중복 검증
+        // 쿠폰 마감일자 최신순으로 조회
         List<Coupon> coupons = couponRepository.findAllByOrderByClosedAtDesc();
-        if(!coupons.isEmpty()){
-            LocalDateTime lastCouponClosedAt = coupons.get(0).getClosedAt();
-            if(param.getOpenAt().isBefore(lastCouponClosedAt)){
-                throw new IllegalArgumentException("새 쿠폰의 시작일은 기존 쿠폰의 발급 마감일( " + lastCouponClosedAt + " )보다 이후여야 합니다.");
-            }
-        }
 
         // 쿠폰 생성
-        Coupon coupon = Coupon.CreateCoupon(param);
+        Coupon coupon = Coupon.CreateCoupon(param, coupons);
 
         couponRepository.save(coupon);
 

--- a/src/main/resources/static/js/create-coupon.js
+++ b/src/main/resources/static/js/create-coupon.js
@@ -1,4 +1,4 @@
-document.addEventListener("DOMContentLoaded", function() {
+document.addEventListener("DOMContentLoaded", function () {
     console.log("DOMContentLoaded event triggered");
     // 페이지 로드 시 관리자 권한 확인
     fetch('/user/check-role')
@@ -41,16 +41,16 @@ document.getElementById("create").addEventListener("click", function () {
     const closedAtDate = new Date(formData.closedAt);
     const expiredAtDate = new Date(formData.expiredAt);
 
-    if(openAtDate >= closedAtDate){
+    if (openAtDate >= closedAtDate) {
         alert("쿠폰 발급 시작일은 쿠폰 발급 마감일보다 이전이어야 합니다.");
         return;
     }
-    if(openAtDate >= expiredAtDate){
+    if (openAtDate >= expiredAtDate) {
         alert("쿠폰 발급 시작일은 쿠폰 만료일보다 이전이어야 합니다.");
         return;
     }
-    if(closedAtDate >= expiredAtDate){
-        alert( "쿠폰 발급 마감일은 쿠폰 만료일보다 이전이어야 합니다.");
+    if (closedAtDate >= expiredAtDate) {
+        alert("쿠폰 발급 마감일은 쿠폰 만료일보다 이전이어야 합니다.");
         return;
     }
 
@@ -63,49 +63,22 @@ document.getElementById("create").addEventListener("click", function () {
     };
     console.log("Sending data: ", formData);
 
-    fetch(`/admin/coupon/exists?openAt=${encodeURIComponent(formData.openAt)}&closedAt=${encodeURIComponent(formData.closedAt)}`)
+    fetch("/admin/coupon", requestOptions)
         .then(response => {
-            if (!response.ok) {
-                throw new Error('Network response was not ok');
+            if (response.ok) {
+                return response.json().catch(() => ({}));  // 응답이 비어있으면 빈 객체 반환
+            } else {
+                return response.json().then(errorData => {
+                    throw new Error(errorData.error || "Unknown error");
+                });
             }
-            return response.json();
         })
         .then(data => {
-            if (data) {
-                alert("해당 기간에 이미 쿠폰이 존재합니다.");
-            } else {
-                // 쿠폰 생성 요청
-                const requestOptions = {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json'
-                    },
-                    body: JSON.stringify(formData)
-                };
-                console.log("Sending data: ", formData);
-
-                fetch("/admin/coupon", requestOptions)
-                    .then(response => {
-                        if (response.ok) {
-                            return response.json().catch(() => ({}));  // 응답이 비어있으면 빈 객체 반환
-                        } else {
-                            return response.json().then(errorData => {
-                                throw new Error(errorData.error || "Unknown error");
-                            });
-                        }
-                    })
-                    .then(data => {
-                        console.log("Success: ", data);
-                        window.location.href = "/";
-                    })
-                    .catch((error) => {
-                        console.error("Error: ", error);
-                        alert("쿠폰 생성에 실패했습니다.");
-                    });
-            }
+            console.log("Success: ", data);
+            window.location.href = "/";
         })
-        .catch(error => {
-            console.error('Error checking coupon existence:', error);
-            alert('쿠폰 중복 확인 중 오류가 발생했습니다.');
+        .catch((error) => {
+            console.error("Error: ", error);
+            alert("쿠폰 생성에 실패했습니다.");
         });
 });


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #46 

## 📝 Description

생성하고자 하는 쿠폰의 openAt 과 closedAt 의 조건
- 기존 쿠폰의 openAt 과 closedAt 날짜 사이에 위치하면 안된다.
- 기존 쿠폰의 openAt 과 closedAt 의 날짜와 같으면 안된다.
- 기존 쿠폰의 closedAt 보다 이후여야 한다.

위의 조건을 토대로 로직을 재구성하였습니다. 
- `CouponService`의 `createCoupon()`메서드에서 쿠폰을 생성하기 전에 조건문이 실행됩니다. 기존 쿠폰의 `closedAt`을 내림차순으로 정렬한 후, 첫 번째 쿠폰의 `closedAt`과 새로 생성하려는 쿠폰의 `openAt`을 비교하여 겹친다면 예외를 발생시키는 방식입니다.
- CouponService 에서 Coupon.java 로 로직을 이동한 뒤 날짜 검증 로직을 checkClosedAt() 메서드로 분리했습니다. 
## 💬 To Reivewers

- 수정한 조건이 원활하게 작동되는지 확인 부탁드립니다.
