### PR TITLE
종료된 쿠폰 페이지 및 동적 페이징 로직 통합

### DIFF
--- a/src/main/java/com/coupon/issuecouponservice/config/WebSecurityConfig.java
+++ b/src/main/java/com/coupon/issuecouponservice/config/WebSecurityConfig.java
@@ -66,8 +66,13 @@ public class WebSecurityConfig {
                     @Override
                     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
                         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-                        response.setContentType("application/json");
-                        response.getWriter().write("{\"error\": \"Unauthorized\", \"message\": \"" + authException.getMessage() + "\"}");
+                        if ("XMLHttpRequest".equals(request.getHeader("X-Requested-With"))) {
+                            response.setContentType("application/json");
+                            response.getWriter().write("{\"redirectUrl\": \"/login\"}");
+                        } else {
+                            // 일반 요청 처리
+                            response.sendRedirect("/login");
+                        }
                     }
                 })
         );

--- a/src/main/java/com/coupon/issuecouponservice/controller/HomeController.java
+++ b/src/main/java/com/coupon/issuecouponservice/controller/HomeController.java
@@ -46,7 +46,16 @@ public class HomeController {
     }
 
     @GetMapping("/past-coupons")
-    public String past() {
+    public String past(Model model, @PageableDefault(size = 9) Pageable pageable) {
+
+        Page<CouponForm> coupons = couponService.readAllClosedCoupons(pageable);
+
+        PaginationUtils paginationUtils = new PaginationUtils(coupons, 10);
+
+        model.addAttribute("coupons", coupons);
+        model.addAttribute("count", (int) coupons.getTotalElements());
+        model.addAttribute("paginationUtils", paginationUtils);
+
         return "past-coupons";
     }
 

--- a/src/main/java/com/coupon/issuecouponservice/dto/response/coupon/CouponForm.java
+++ b/src/main/java/com/coupon/issuecouponservice/dto/response/coupon/CouponForm.java
@@ -21,6 +21,7 @@ public class CouponForm {
     public CouponForm(Coupon coupon) {
         this.couponId = coupon.getId();
         this.couponName = coupon.getCouponName();
+        this.couponContent = coupon.getCouponContent();
         this.totalQuantity = coupon.getTotalQuantity();
         this.remainQuantity = coupon.getRemainQuantity();
         this.validityStatus = coupon.getValidityStatus();

--- a/src/main/java/com/coupon/issuecouponservice/dto/response/coupon/CouponForm.java
+++ b/src/main/java/com/coupon/issuecouponservice/dto/response/coupon/CouponForm.java
@@ -16,6 +16,7 @@ public class CouponForm {
     private ValidityStatus validityStatus;
     private LocalDateTime createdAt;
     private LocalDateTime expiredAt;
+    private LocalDateTime closedAt;
 
     public CouponForm(Coupon coupon) {
         this.couponId = coupon.getId();
@@ -25,6 +26,7 @@ public class CouponForm {
         this.validityStatus = coupon.getValidityStatus();
         this.createdAt = coupon.getCreatedAt();
         this.expiredAt = coupon.getExpiredAt();
+        this.closedAt = coupon.getClosedAt();
     }
 
     public CouponForm(Coupon coupon, LocalDateTime createdAt) {

--- a/src/main/java/com/coupon/issuecouponservice/repository/coupon/CouponRepository.java
+++ b/src/main/java/com/coupon/issuecouponservice/repository/coupon/CouponRepository.java
@@ -1,6 +1,8 @@
 package com.coupon.issuecouponservice.repository.coupon;
 
 import com.coupon.issuecouponservice.domain.coupon.Coupon;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -23,6 +25,10 @@ public interface CouponRepository extends JpaRepository<Coupon, Long> {
     // 진행 중 쿠폰 조회
     @Query("select c from Coupon c where c.couponStatus = 'ACTIVE' and c.isDeleted = false ")
     Optional<Coupon> findActiveCoupon();
+
+    // 종료 된 쿠폰 조회
+    @Query("select c from Coupon c where c.couponStatus = 'CLOSED' and c.isDeleted = false order by c.closedAt")
+    Page<Coupon> findClosedCoupons(Pageable pageable);
 
     List<Coupon> findAllByOrderByClosedAtDesc();
 }

--- a/src/main/java/com/coupon/issuecouponservice/service/coupon/CouponService.java
+++ b/src/main/java/com/coupon/issuecouponservice/service/coupon/CouponService.java
@@ -62,6 +62,16 @@ public class CouponService {
         return findCoupon != null ? new CouponOneForm(findCoupon) : null;
     }
 
+
+    // 종료된 쿠폰 전체 조회
+    @Transactional(readOnly = true)
+    public Page<CouponForm> readAllClosedCoupons(Pageable pageable) {
+        // 쿠폰 목록 조회
+        Page<Coupon> findCoupons = couponRepository.findClosedCoupons(pageable);
+
+        return findCoupons.map(CouponForm::new);
+    }
+
     // 쿠폰 수정
     public void modifyCoupon(Long couponId, CouponModificationParam param) {
         // 쿠폰 이름 중복 검증

--- a/src/main/resources/templates/past-coupons.html
+++ b/src/main/resources/templates/past-coupons.html
@@ -58,8 +58,9 @@
                                 <small class="text-body-secondary"><span>총재고 : </span>
                                     <span th:text="${coupon.totalQuantity}">100</span><span>장</span>
                                 </small>
-                                <small th:text="${#temporals.format(coupon.closedAt, 'yyyy-MM-dd')}"
-                                       class="text-body-secondary">발급 마감일</small>
+                                <small class="text-body-secondary">마감 일자
+                                    <span th:text="${#temporals.format(coupon.closedAt, 'yyyy-MM-dd')}"></span>
+                                </small>
                             </div>
                         </div>
                     </div>

--- a/src/main/resources/templates/past-coupons.html
+++ b/src/main/resources/templates/past-coupons.html
@@ -38,6 +38,11 @@
 <div class="container d-flex flex-column full-height full-width bg-custom">
     <div class="album py-5 bg-transparent">
         <div class="container">
+            <div class="d-flex justify-content-center text-center mt-5" th:if="${count == 0}">
+                <div class="d-flex justify-content-center align-items-center p-3 bg-white bg-opacity-50 rounded-3 shadow" style="width: 70%; height: 300px;">
+                    <h2 class="fw-normal">아직 종료된 쿠폰이 없어요 😅</h2>
+                </div>
+            </div>
             <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 g-3">
                 <div th:each="coupon : ${coupons}" class="col">
                     <div class="card shadow-sm">

--- a/src/main/resources/templates/past-coupons.html
+++ b/src/main/resources/templates/past-coupons.html
@@ -20,6 +20,9 @@
             integrity="sha384-0pUGZvbkm6XF6gxjEnlmuGrJXVbNuzT9qBBavbLwCsOGabYfZo0T0to5eqruptLy"
             crossorigin="anonymous"></script>
 
+    <!-- Font Awesome -->
+    <script src="https://kit.fontawesome.com/48e8469b97.js" crossorigin="anonymous"></script>
+
     <!-- CSS -->
     <link rel="stylesheet" type="text/css" href="/css/styles.css">
     <title>Coukyrun - 종료된 쿠폰</title>
@@ -36,7 +39,7 @@
     <div class="album py-5 bg-transparent">
         <div class="container">
             <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 g-3">
-                <div class="col">
+                <div th:each="coupon : ${coupons}" class="col">
                     <div class="card shadow-sm">
                         <svg class="bd-placeholder-img card-img-top" width="100%" height="225"
                              xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder: Thumbnail"
@@ -48,233 +51,66 @@
                             </text>
                         </svg>
                         <div class="card-body d-flex flex-column">
-                            <h2 class="fw-normal">쿠폰 이름 1</h2>
-                            <p class="card-text">쿠폰에 대한 설명이 기재될 예정입니다. 이 쿠폰은 행운을 가져다주는 특별한 쿠폰으로,
+                            <h2 th:text="${coupon.couponName}">쿠폰 이름 1</h2>
+                            <p th:text="${coupon.couponContent}">쿠폰에 대한 설명이 기재될 예정입니다. 이 쿠폰은 행운을 가져다주는 특별한 쿠폰으로,
                                 사용 시 당신에게 엄청난 행운이 찾아갈 것입니다. 얼른 쿠폰을 발급 받으세요. 100자</p>
                             <div class="d-flex justify-content-between align-items-center mt-auto">
                                 <small class="text-body-secondary"><span>총재고 : </span>
-                                    <span>100</span><span>장</span>
+                                    <span th:text="${coupon.totalQuantity}">100</span><span>장</span>
                                 </small>
-                                <small class="text-body-secondary">발급 마감일</small>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div class="col">
-                    <div class="card shadow-sm">
-                        <svg class="bd-placeholder-img card-img-top" width="100%" height="225"
-                             xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder: Thumbnail"
-                             preserveAspectRatio="xMidYMid slice" focusable="false">
-                            <title>Placeholder</title>
-                            <rect width="100%" height="100%" fill="#55595c"/>
-                            <text x="50%" y="50%" fill="#eceeef" dy=".3em" text-anchor="middle"
-                                  dominant-baseline="central">Thumbnail
-                            </text>
-                        </svg>
-                        <div class="card-body d-flex flex-column">
-                            <h2 class="fw-normal">쿠폰 이름 2</h2>
-                            <p class="card-text">쿠폰에 대한 설명이 기재될 예정입니다. 이 쿠폰은 행운을 가져다주는 특별한 쿠폰으로,
-                                사용 시 당신에게 엄청난 행운이 찾아갈 것입니다. 80자.</p>
-                            <div class="d-flex justify-content-between align-items-center mt-auto">
-                                <small class="text-body-secondary"><span>총재고 : </span>
-                                    <span>100</span><span>장</span>
-                                </small>
-                                <small class="text-body-secondary">발급 마감일</small>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div class="col">
-                    <div class="card shadow-sm">
-                        <svg class="bd-placeholder-img card-img-top" width="100%" height="225"
-                             xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder: Thumbnail"
-                             preserveAspectRatio="xMidYMid slice" focusable="false">
-                            <title>Placeholder</title>
-                            <rect width="100%" height="100%" fill="#55595c"/>
-                            <text x="50%" y="50%" fill="#eceeef" dy=".3em" text-anchor="middle"
-                                  dominant-baseline="central">Thumbnail
-                            </text>
-                        </svg>
-                        <div class="card-body d-flex flex-column">
-                            <h2 class="fw-normal">쿠폰 이름 3</h2>
-                            <p class="card-text">쿠폰에 대한 설명이 기재될 예정입니다. 이 쿠폰은 행운을 가져다주는 특별한 쿠폰입니다. 50자.</p>
-                            <div class="d-flex justify-content-between align-items-center mt-auto">
-                                <small class="text-body-secondary"><span>총재고 : </span>
-                                    <span>100</span><span>장</span>
-                                </small>
-                                <small class="text-body-secondary">발급 마감일</small>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="col">
-                    <div class="card shadow-sm">
-                        <svg class="bd-placeholder-img card-img-top" width="100%" height="225"
-                             xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder: Thumbnail"
-                             preserveAspectRatio="xMidYMid slice" focusable="false">
-                            <title>Placeholder</title>
-                            <rect width="100%" height="100%" fill="#55595c"/>
-                            <text x="50%" y="50%" fill="#eceeef" dy=".3em" text-anchor="middle"
-                                  dominant-baseline="central">Thumbnail
-                            </text>
-                        </svg>
-                        <div class="card-body d-flex flex-column">
-                            <h2 class="fw-normal">쿠폰 이름 4</h2>
-                            <p class="card-text">쿠폰에 대한 설명이 기재될 예정입니다. 20자.</p>
-                            <div class="d-flex justify-content-between align-items-center mt-auto">
-                                <small class="text-body-secondary"><span>총재고 : </span>
-                                    <span>100</span><span>장</span>
-                                </small>
-                                <small class="text-body-secondary">발급 마감일</small>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div class="col">
-                    <div class="card shadow-sm">
-                        <svg class="bd-placeholder-img card-img-top" width="100%" height="225"
-                             xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder: Thumbnail"
-                             preserveAspectRatio="xMidYMid slice" focusable="false">
-                            <title>Placeholder</title>
-                            <rect width="100%" height="100%" fill="#55595c"/>
-                            <text x="50%" y="50%" fill="#eceeef" dy=".3em" text-anchor="middle"
-                                  dominant-baseline="central">Thumbnail
-                            </text>
-                        </svg>
-                        <div class="card-body d-flex flex-column">
-                            <h2 class="fw-normal">쿠폰 이름 3</h2>
-                            <p class="card-text">쿠폰에 대한 설명이 기재될 예정입니다. 이 쿠폰은 행운을 가져다주는 특별한 쿠폰입니다. 50자.</p>
-                            <div class="d-flex justify-content-between align-items-center mt-auto">
-                                <small class="text-body-secondary"><span>총재고 : </span>
-                                    <span>100</span><span>장</span>
-                                </small>
-                                <small class="text-body-secondary">발급 마감일</small>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div class="col">
-                    <div class="card shadow-sm">
-                        <svg class="bd-placeholder-img card-img-top" width="100%" height="225"
-                             xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder: Thumbnail"
-                             preserveAspectRatio="xMidYMid slice" focusable="false">
-                            <title>Placeholder</title>
-                            <rect width="100%" height="100%" fill="#55595c"/>
-                            <text x="50%" y="50%" fill="#eceeef" dy=".3em" text-anchor="middle"
-                                  dominant-baseline="central">Thumbnail
-                            </text>
-                        </svg>
-                        <div class="card-body d-flex flex-column">
-                            <h2 class="fw-normal">쿠폰 이름 3</h2>
-                            <p class="card-text">쿠폰에 대한 설명이 기재될 예정입니다. 이 쿠폰은 행운을 가져다주는 특별한 쿠폰입니다. 50자.</p>
-                            <div class="d-flex justify-content-between align-items-center mt-auto">
-                                <small class="text-body-secondary"><span>총재고 : </span>
-                                    <span>100</span><span>장</span>
-                                </small>
-                                <small class="text-body-secondary">발급 마감일</small>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="col">
-                    <div class="card shadow-sm">
-                        <svg class="bd-placeholder-img card-img-top" width="100%" height="225"
-                             xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder: Thumbnail"
-                             preserveAspectRatio="xMidYMid slice" focusable="false">
-                            <title>Placeholder</title>
-                            <rect width="100%" height="100%" fill="#55595c"/>
-                            <text x="50%" y="50%" fill="#eceeef" dy=".3em" text-anchor="middle"
-                                  dominant-baseline="central">Thumbnail
-                            </text>
-                        </svg>
-                        <div class="card-body d-flex flex-column">
-                            <h2 class="fw-normal">쿠폰 이름 3</h2>
-                            <p class="card-text">쿠폰에 대한 설명이 기재될 예정입니다. 이 쿠폰은 행운을 가져다주는 특별한 쿠폰입니다. 50자.</p>
-                            <div class="d-flex justify-content-between align-items-center mt-auto">
-                                <small class="text-body-secondary"><span>총재고 : </span>
-                                    <span>100</span><span>장</span>
-                                </small>
-                                <small class="text-body-secondary">발급 마감일</small>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div class="col">
-                    <div class="card shadow-sm">
-                        <svg class="bd-placeholder-img card-img-top" width="100%" height="225"
-                             xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder: Thumbnail"
-                             preserveAspectRatio="xMidYMid slice" focusable="false">
-                            <title>Placeholder</title>
-                            <rect width="100%" height="100%" fill="#55595c"/>
-                            <text x="50%" y="50%" fill="#eceeef" dy=".3em" text-anchor="middle"
-                                  dominant-baseline="central">Thumbnail
-                            </text>
-                        </svg>
-                        <div class="card-body d-flex flex-column">
-                            <h2 class="fw-normal">쿠폰 이름 3</h2>
-                            <p class="card-text">쿠폰에 대한 설명이 기재될 예정입니다. 이 쿠폰은 행운을 가져다주는 특별한 쿠폰입니다. 50자.</p>
-                            <div class="d-flex justify-content-between align-items-center mt-auto">
-                                <small class="text-body-secondary"><span>총재고 : </span>
-                                    <span>100</span><span>장</span>
-                                </small>
-                                <small class="text-body-secondary">발급 마감일</small>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div class="col">
-                    <div class="card shadow-sm">
-                        <svg class="bd-placeholder-img card-img-top" width="100%" height="225"
-                             xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder: Thumbnail"
-                             preserveAspectRatio="xMidYMid slice" focusable="false">
-                            <title>Placeholder</title>
-                            <rect width="100%" height="100%" fill="#55595c"/>
-                            <text x="50%" y="50%" fill="#eceeef" dy=".3em" text-anchor="middle"
-                                  dominant-baseline="central">Thumbnail
-                            </text>
-                        </svg>
-                        <div class="card-body d-flex flex-column">
-                            <h2 class="fw-normal">쿠폰 이름 3</h2>
-                            <p class="card-text">쿠폰에 대한 설명이 기재될 예정입니다. 이 쿠폰은 행운을 가져다주는 특별한 쿠폰입니다. 50자.</p>
-                            <div class="d-flex justify-content-between align-items-center mt-auto">
-                                <small class="text-body-secondary"><span>총재고 : </span>
-                                    <span>100</span><span>장</span>
-                                </small>
-                                <small class="text-body-secondary">발급 마감일</small>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="col">
-                    <div class="card shadow-sm">
-                        <svg class="bd-placeholder-img card-img-top" width="100%" height="225"
-                             xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder: Thumbnail"
-                             preserveAspectRatio="xMidYMid slice" focusable="false">
-                            <title>Placeholder</title>
-                            <rect width="100%" height="100%" fill="#55595c"/>
-                            <text x="50%" y="50%" fill="#eceeef" dy=".3em" text-anchor="middle"
-                                  dominant-baseline="central">Thumbnail
-                            </text>
-                        </svg>
-                        <div class="card-body d-flex flex-column">
-                            <h2 class="fw-normal">쿠폰 이름 3</h2>
-                            <p class="card-text">쿠폰에 대한 설명이 기재될 예정입니다. 이 쿠폰은 행운을 가져다주는 특별한 쿠폰입니다. 50자.</p>
-                            <div class="d-flex justify-content-between align-items-center mt-auto">
-                                <small class="text-body-secondary"><span>총재고 : </span>
-                                    <span>100</span><span>장</span>
-                                </small>
-                                <small class="text-body-secondary">발급 마감일</small>
+                                <small th:text="${#temporals.format(coupon.closedAt, 'yyyy-MM-dd')}"
+                                       class="text-body-secondary">발급 마감일</small>
                             </div>
                         </div>
                     </div>
                 </div>
             </div>
         </div>
-        <nav aria-label="Page navigation example" class="mt-5">
-            <ul class="pagination justify-content-center" id="pagination">
+
+        <nav class="d-flex justify-content-center" aria-label="Page navigation" th:if="${count > 0} ">
+            <ul class="pagination mt-5">
+                <!-- 처음 페이지로 이동: 첫 번째 그룹에서는 항상 렌더링, 2페이지 이상에서 활성화 -->
+                <li class="page-item" th:if="${paginationUtils.totalGroups > 1 || paginationUtils.currentPage > 1}">
+                    <a class="page-link" th:href="@{/past-coupons(page=0, size=${coupons.size})}" aria-label="First"
+                       th:classappend="${paginationUtils.currentPage == 1 ? 'disabled' : ''}">
+                        <i class="fa-solid fa-angles-left"></i>
+                    </a>
+                </li>
+
+                <!-- 이전 페이지 그룹으로 이동: 첫 번째 그룹에서는 렌더링되지만 비활성화 -->
+                <li class="page-item" th:if="${paginationUtils.totalGroups > 1}"
+                    th:classappend="${paginationUtils.isFirstGroup ? 'disabled' : ''}">
+                    <a class="page-link"
+                       th:href="@{/past-coupons(page=${paginationUtils.isFirstGroup ? paginationUtils.currentPage - 1 : paginationUtils.startPage - 2}, size=${coupons.size})}"
+                       aria-label="Previous Group">
+                        <i class="fa-solid fa-angle-left"></i>
+                    </a>
+                </li>
+
+                <!-- 페이지 번호 표시 -->
+                <li th:each="i : ${#numbers.sequence(paginationUtils.startPage, paginationUtils.endPage)}"
+                    th:class="${i == paginationUtils.currentPage ? 'page-item active' : 'page-item'}">
+                    <a class="page-link" th:href="@{/past-coupons(page=${i - 1}, size=${coupons.size})}"
+                       th:text="${i}"></a>
+                </li>
+
+                <!-- 다음 페이지 그룹으로 이동 -->
+                <li class="page-item" th:if="${!paginationUtils.isLastGroup}">
+                    <a class="page-link"
+                       th:href="@{/past-coupons(page=${paginationUtils.endPage}, size=${coupons.size})}"
+                       aria-label="Next Group">
+                        <i class="fa-solid fa-angle-right"></i>
+                    </a>
+                </li>
+
+                <!-- 마지막 페이지로 이동 -->
+                <li class="page-item" th:if="${!paginationUtils.isLastGroup}">
+                    <a class="page-link"
+                       th:href="@{/past-coupons(page=${paginationUtils.totalPages - 1}, size=${coupons.size})}"
+                       aria-label="Last">
+                        <i class="fa-solid fa-angles-right"></i>
+                    </a>
+                </li>
             </ul>
         </nav>
     </div>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #55 

## 📝 Description

1. 종료된 쿠폰 조회 로직 구현

- CouponRepository에 findClosedCoupons 쿼리 메서드를 추가하고, @GetMapping("/past-coupons")를 통해 종료된 쿠폰을 조회합니다.
- 페이지당 9개의 쿠폰을 보여주며, 10개 단위로 페이지 그룹을 설정하여 페이징 처리를 구현하였습니다.

2.  프론트엔드 쿠폰 목록 동적 표시 및 페이징
- Thymeleaf의 th:each를 활용하여 서버로부터 받은 쿠폰 목록을 동적으로 페이지에 렌더링합니다.

3. 종료된 쿠폰 없음 메시지 처리
- 쿠폰 데이터가 없을 때 사용자에게 "쿠폰이 존재하지 않습니다"라는 메시지를 동적으로 보여주는 기능을 추가하였습니다. 

4. JavaScript 코드 정리 및 개선
- 중복된 DOMContentLoaded 리스너를 통합하였습니다.
- 불필요한 코드를 삭제하였습니다.


## 💬 To Reivewers

확인 후 피드백 부탁드립니다.
