### PR TITLE
로그아웃 기능 구현

### DIFF
--- a/src/main/java/com/coupon/issuecouponservice/config/WebSecurityConfig.java
+++ b/src/main/java/com/coupon/issuecouponservice/config/WebSecurityConfig.java
@@ -2,7 +2,6 @@ package com.coupon.issuecouponservice.config;
 
 import com.coupon.issuecouponservice.security.handler.CustomAuthenticationSuccessHandler;
 import com.coupon.issuecouponservice.security.oauth.PrincipalOauth2UserService;
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -61,10 +60,19 @@ public class WebSecurityConfig {
                         .permitAll()
         );
 
+        http.logout((logout) ->
+                logout
+                        .logoutUrl("/logout")
+                        .logoutSuccessUrl("/") // 사용자 정의 로그아웃 성공 후 리다이렉트 페이지
+                        .invalidateHttpSession(true) // 세션 무효화
+                        .deleteCookies("JSESSIONID", "remember-me") // 추가적인 쿠키 삭제
+                        .permitAll()
+        );
+
         http.exceptionHandling((exception) ->
                 exception.authenticationEntryPoint(new AuthenticationEntryPoint() {
                     @Override
-                    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+                    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
                         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
                         if ("XMLHttpRequest".equals(request.getHeader("X-Requested-With"))) {
                             response.setContentType("application/json");
@@ -76,6 +84,7 @@ public class WebSecurityConfig {
                     }
                 })
         );
+
         return http.build();
     }
 

--- a/src/main/resources/templates/nav-bar-1st.html
+++ b/src/main/resources/templates/nav-bar-1st.html
@@ -1,5 +1,6 @@
 <!doctype html>
-<html lang="ko">
+<html lang="ko"
+      xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
 <head>
   <meta charset="utf-8">
   <!--Viewport-->
@@ -32,8 +33,13 @@
   <nav class="py-2 bg-white">
     <div class="container-fluid d-flex flex-wrap">
       <ul class="nav ms-auto">
-        <li class="nav-item"><a href="/my-page" class="nav-link link-body-emphasis" id="nav-my-page">마이페이지</a></li>
-        <li class="nav-item"><a href="#" class="nav-link link-body-emphasis">로그아웃</a></li>
+        <li class="nav-item" sec:authorize="isAuthenticated()"><a href="/my-page" class="nav-link link-body-emphasis" id="nav-my-page">마이페이지</a></li>
+        <li class="nav-item" sec:authorize="isAuthenticated()">
+          <a href="/logout" class="nav-link link-body-emphasis">로그아웃</a>
+        </li>
+        <li class="nav-item" sec:authorize="isAnonymous()">
+          <a href="/login" class="nav-link link-body-emphasis">로그인</a>
+        </li>
       </ul>
     </div>
   </nav>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

-  #57 

## 📝 Description

1. Thymeleaf 보안 태그를 활용한 동적 네비게이션 바 업데이트
- `html` 태그에 Thymeleaf의 보안 네임스페이스를 추가하였습니다.

- 로그인 및 로그아웃 버튼에 대한 클릭 이벤트를 구현하여 각 상태에 맞게 동작하도록 했습니다. 로그인 상태에 따라 네비게이션 바에 '로그인' 또는 '로그아웃' 링크가 동적으로 표시됩니다.

- 인증된 사용자만 '마이페이지'에 접근할 수 있도록 제한을 두었습니다.

2. 로그아웃 설정 세부 조정
- 로그아웃 기능의 안정성을 향상시키기 위해 로그아웃 요청의 경로를 '/logout'으로 명시적으로 설정했습니다.

- 사용자가 로그아웃을 성공적으로 수행하면 자동으로 홈페이지('/')로 리다이렉트되도록 했습니다.

## 💬 To Reivewers

검토 후 피드백 부탁드립니다.